### PR TITLE
Update CI branch list after master→main rename

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main, master, development]
+    branches: [main, development]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Remove `master` from CI workflow branch triggers since the default branch is now `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)