### PR TITLE
fix: Replace tokenizer.json with vocab.json in required files list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.9.5
+**Current Version**: 0.9.7
 
 ---
 
@@ -106,7 +106,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.9.5)
+│       ├── Version.swift              # Version constant (0.9.7)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)
@@ -156,7 +156,7 @@ Implements SwiftHablare's `VoiceProvider` protocol with dual-mode routing.
 
 ```swift
 public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
-    public static let version = "0.9.5"
+    public static let version = "0.9.7"
 
     // VoiceProvider protocol properties
     public let providerId = "voxalta"
@@ -648,6 +648,16 @@ On CI (`GITHUB_ACTIONS` set):
 ---
 
 ## Recent Changes
+
+### v0.9.7
+
+- **fix**: Replace tokenizer.json with vocab.json in required files list
+- Qwen3-TTS models use BPE tokenizer format (vocab.json + merges.txt), not tokenizer.json
+- Fixes fileNotInManifest errors on every voice generation attempt
+
+### v0.9.6
+
+- Bump SwiftTuberia dependency to 0.2.6
 
 ### v0.9.5
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BIN_DIR = ./bin
 DESTINATION = platform=macOS,arch=arm64
 DERIVED_DATA = $(HOME)/Library/Developer/Xcode/DerivedData
 
-.PHONY: all build release install clean test test-unit test-integration setup-voices resolve lint help
+.PHONY: all build release install clean test test-unit test-integration test-cdn setup-voices resolve lint help
 
 all: install
 
@@ -75,8 +75,18 @@ else
 	@echo "Local run: Running all tests (DigaTests + SwiftVoxAltaTests)"
 	xcodebuild test \
 	  -scheme $(TEST_SCHEME) \
-	  -destination '$(DESTINATION)'
+	  -destination '$(DESTINATION)' \
+	  -skip-testing:SwiftVoxAltaTests/CDNAvailabilityTests
 endif
+
+# CDN availability tests (requires network access; downloads config.json only)
+# Validates that all 7 Qwen3-TTS models are reachable on the Acervo CDN.
+test-cdn:
+	@echo "Running CDN availability tests (network required)..."
+	xcodebuild test \
+	  -scheme $(TEST_SCHEME) \
+	  -destination '$(DESTINATION)' \
+	  -only-testing:SwiftVoxAltaTests/CDNAvailabilityTests
 
 # Integration tests (requires binary + cached voices)
 # TODO: Create DigaBinaryIntegrationTests and DigaDualModelIntegrationTests test suites
@@ -119,6 +129,7 @@ help:
 	@echo "  test            - Run all tests (unit + integration)"
 	@echo "  test-unit       - Run fast unit tests only (no binary required)"
 	@echo "  test-integration - Run binary integration tests (requires binary + voices)"
+	@echo "  test-cdn        - Check all Qwen3-TTS models are available on CDN (requires network)"
 	@echo "  setup-voices    - One-time setup: generate voices for local testing"
 	@echo "  clean           - Clean build artifacts"
 	@echo "  help            - Show this help"

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "5.0.0"),
     .package(url: "https://github.com/intrusive-memory/mlx-audio-swift.git", from: "0.3.0"),
-    .package(url: "https://github.com/intrusive-memory/SwiftAcervo.git", from: "0.5.0"),
+    .package(url: "https://github.com/intrusive-memory/SwiftAcervo.git", from: "0.6.0"),
     .package(url: "https://github.com/intrusive-memory/SwiftTuberia.git", from: "0.2.7"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
     .package(url: "https://github.com/intrusive-memory/vox-format.git", from: "0.3.0"),

--- a/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
@@ -127,7 +127,7 @@ extension Qwen3TTSModelRepo {
 /// `Acervo.ensureComponentReady()` knows exactly what to download.
 private let qwen3TTSRequiredFiles: [ComponentFile] = [
   ComponentFile(relativePath: "config.json"),
-  ComponentFile(relativePath: "tokenizer.json"),
+  ComponentFile(relativePath: "vocab.json"),
   ComponentFile(relativePath: "tokenizer_config.json"),
   ComponentFile(relativePath: "model.safetensors"),
 ]

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -29,7 +29,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.9.5"
+  public static let version = "0.9.7"
 
   // MARK: - VoiceProvider Metadata
 


### PR DESCRIPTION
Qwen3-TTS models use BPE tokenizer format (vocab.json + merges.txt), not the tokenizer.json format. The wrong filename caused fileNotInManifest errors on every voice generation attempt.