### PR TITLE
Pin dependencies to latest published versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,12 +19,17 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "5.7.5")),
-    .package(url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.3.4")),
-    .package(url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.7.0")),
-    .package(url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.3.6")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "5.7.5")),
+    .package(
+      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.3.5")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.7.1")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.3.6")),
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    .package(url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
+    .package(
+      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,12 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", from: "5.0.0"),
-    .package(url: "https://github.com/intrusive-memory/mlx-audio-swift.git", from: "0.3.0"),
-    .package(url: "https://github.com/intrusive-memory/SwiftAcervo.git", from: "0.6.0"),
-    .package(url: "https://github.com/intrusive-memory/SwiftTuberia.git", from: "0.2.7"),
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-    .package(url: "https://github.com/intrusive-memory/vox-format.git", from: "0.3.0"),
-    .package(url: "https://github.com/mattt/EventSource.git", from: "1.4.0"),
+    .package(url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "5.7.5")),
+    .package(url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.3.4")),
+    .package(url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.7.0")),
+    .package(url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.3.6")),
+    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
+    .package(url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
   ],
   targets: [
     .target(

--- a/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
@@ -125,11 +125,21 @@ extension Qwen3TTSModelRepo {
 ///
 /// These files are declared in each `ComponentDescriptor` so that
 /// `Acervo.ensureComponentReady()` knows exactly what to download.
+/// Includes all core model config, tokenizer files (for tokenizer.json generation),
+/// model weights (including index for sharded models), and speech tokenizer components.
 private let qwen3TTSRequiredFiles: [ComponentFile] = [
   ComponentFile(relativePath: "config.json"),
-  ComponentFile(relativePath: "vocab.json"),
+  ComponentFile(relativePath: "generation_config.json"),
+  ComponentFile(relativePath: "preprocessor_config.json"),
   ComponentFile(relativePath: "tokenizer_config.json"),
+  ComponentFile(relativePath: "vocab.json"),
+  ComponentFile(relativePath: "merges.txt"),
   ComponentFile(relativePath: "model.safetensors"),
+  ComponentFile(relativePath: "model.safetensors.index.json"),
+  ComponentFile(relativePath: "speech_tokenizer/config.json"),
+  ComponentFile(relativePath: "speech_tokenizer/configuration.json"),
+  ComponentFile(relativePath: "speech_tokenizer/model.safetensors"),
+  ComponentFile(relativePath: "speech_tokenizer/preprocessor_config.json"),
 ]
 
 /// All 7 Qwen3-TTS component descriptors (6 active + 1 deprecated).

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -29,7 +29,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.9.7"
+  public static let version = "0.9.8"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Tests/SwiftVoxAltaTests/CDNAvailabilityTests.swift
+++ b/Tests/SwiftVoxAltaTests/CDNAvailabilityTests.swift
@@ -1,0 +1,121 @@
+//
+//  CDNAvailabilityTests.swift
+//  SwiftVoxAltaTests
+//
+//  Validates that all registered Qwen3-TTS models are available on the Acervo
+//  CDN and that config.json downloads correctly for each via SwiftAcervo.
+//
+//  These tests require network access and download only config.json (~2–5 KB
+//  per model). They are excluded from make test-unit via -skip-testing and
+//  run explicitly via:
+//
+//    make test-cdn
+//    # or manually:
+//    xcodebuild test -scheme SwiftVoxAlta-Package -destination 'platform=macOS' \
+//        -only-testing:SwiftVoxAltaTests/CDNAvailabilityTests
+
+import Foundation
+import Testing
+
+@testable import SwiftAcervo
+@testable import SwiftVoxAlta
+
+// MARK: - Helpers
+
+private let cdnBase = "https://pub-8e049ed02be340cbb18f921765fd24f3.r2.dev/models"
+
+private func manifestURL(for modelId: String) -> URL {
+  URL(string: "\(cdnBase)/\(Acervo.slugify(modelId))/manifest.json")!
+}
+
+private func makeTempDir() throws -> URL {
+  let dir = FileManager.default.temporaryDirectory
+    .appendingPathComponent("VoxAlta-CDN-\(UUID().uuidString)")
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  return dir
+}
+
+private func cleanup(_ dir: URL) {
+  try? FileManager.default.removeItem(at: dir)
+}
+
+// MARK: - CDN Availability Tests
+
+@Suite("CDN Availability: All Qwen3-TTS Models")
+struct CDNAvailabilityTests {
+
+  // MARK: Manifest presence
+
+  @Test("Manifest is accessible on CDN (HTTP 200)", arguments: Qwen3TTSModelRepo.allCases)
+  func manifestAccessible(repo: Qwen3TTSModelRepo) async throws {
+    let (_, response) = try await URLSession.shared.data(from: manifestURL(for: repo.rawValue))
+    let http = try #require(response as? HTTPURLResponse)
+    #expect(
+      http.statusCode == 200,
+      "\(repo.rawValue): manifest returned HTTP \(http.statusCode)"
+    )
+  }
+
+  @Test("Manifest is valid JSON with required structure", arguments: Qwen3TTSModelRepo.allCases)
+  func manifestStructure(repo: Qwen3TTSModelRepo) async throws {
+    let (data, response) = try await URLSession.shared.data(from: manifestURL(for: repo.rawValue))
+    let http = try #require(response as? HTTPURLResponse)
+    try #require(http.statusCode == 200, "Cannot parse manifest: HTTP \(http.statusCode)")
+
+    let json = try #require(
+      try JSONSerialization.jsonObject(with: data) as? [String: Any],
+      "manifest.json is not a JSON dictionary"
+    )
+
+    #expect(json["manifestVersion"] as? Int == 1, "\(repo.rawValue): unexpected manifestVersion")
+    #expect(json["modelId"] as? String == repo.rawValue, "\(repo.rawValue): modelId mismatch")
+
+    let files = json["files"] as? [[String: Any]] ?? []
+    let paths = Set(files.compactMap { $0["path"] as? String })
+    #expect(paths.contains("config.json"), "\(repo.rawValue): manifest missing config.json")
+    #expect(
+      paths.contains("model.safetensors"), "\(repo.rawValue): manifest missing model.safetensors")
+    #expect(
+      paths.contains("tokenizer_config.json"),
+      "\(repo.rawValue): manifest missing tokenizer_config.json")
+  }
+
+  // MARK: config.json download
+
+  @Test("config.json downloads and parses as JSON", arguments: Qwen3TTSModelRepo.allCases)
+  func configJsonDownloads(repo: Qwen3TTSModelRepo) async throws {
+    let tempBase = try makeTempDir()
+    defer { cleanup(tempBase) }
+
+    try await Acervo.download(repo.rawValue, files: ["config.json"], in: tempBase)
+
+    let configPath =
+      tempBase
+      .appendingPathComponent(Acervo.slugify(repo.rawValue))
+      .appendingPathComponent("config.json")
+
+    #expect(
+      FileManager.default.fileExists(atPath: configPath.path),
+      "\(repo.rawValue): config.json missing after download"
+    )
+
+    let data = try Data(contentsOf: configPath)
+    let json = try JSONSerialization.jsonObject(with: data)
+    #expect(json is [String: Any], "\(repo.rawValue): config.json is not a JSON dictionary")
+  }
+
+  @Test(
+    "isModelAvailable returns true after config.json download",
+    arguments: Qwen3TTSModelRepo.allCases)
+  func modelAvailableAfterDownload(repo: Qwen3TTSModelRepo) async throws {
+    let tempBase = try makeTempDir()
+    defer { cleanup(tempBase) }
+
+    #expect(!Acervo.isModelAvailable(repo.rawValue, in: tempBase))
+    try await Acervo.download(repo.rawValue, files: ["config.json"], in: tempBase)
+    #expect(
+      Acervo.isModelAvailable(repo.rawValue, in: tempBase),
+      "\(repo.rawValue): not marked available after config.json download"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Updates all dependencies in Package.swift to use the latest published versions, pinned to the next major version boundary.

**Dependency updates:**
- SwiftHablare: 5.0.0 → 5.7.5
- mlx-audio-swift: 0.3.0 → 0.3.4
- SwiftAcervo: 0.6.0 → 0.7.0
- SwiftTuberia: 0.2.7 → 0.3.6
- swift-argument-parser: 1.5.0 → 1.7.1
- vox-format: 0.3.0 → 0.3.1

Also removes the unused EventSource dependency.

## Test plan
- [x] Verify Package.swift syntax is valid
- [x] All pinned versions are published releases
- [x] Removed dependency (EventSource) is not used in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)