### PR TITLE
Development → Main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.10.1
+**Current Version**: 0.10.2
 
 ---
 
@@ -106,7 +106,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.10.1)
+│       ├── Version.swift              # Version constant (0.10.2)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)
@@ -156,7 +156,7 @@ Implements SwiftHablare's `VoiceProvider` protocol with dual-mode routing.
 
 ```swift
 public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
-    public static let version = "0.10.1"
+    public static let version = "0.10.2"
 
     // VoiceProvider protocol properties
     public let providerId = "voxalta"

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         sibling(
             "SwiftAcervo",
             remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-            from: "0.8.4"
+            from: "0.10.0"
         ),
         sibling(
             "SwiftTuberia",

--- a/Package.swift
+++ b/Package.swift
@@ -10,107 +10,108 @@ import PackageDescription
 let useLocalSiblings = ProcessInfo.processInfo.environment["CI"] != "true"
 
 func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
+    let localPath = "../\(name)"
+    if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+        return .package(path: localPath)
+    }
+    return .package(url: remote, .upToNextMajor(from: version))
 }
 
 let package = Package(
-  name: "SwiftVoxAlta",
-  platforms: [
-    .macOS(.v26),
-    .iOS(.v26),
-  ],
-  products: [
-    .library(
-      name: "SwiftVoxAlta",
-      targets: ["SwiftVoxAlta"]
-    ),
-    .executable(
-      name: "diga",
-      targets: ["diga"]
-    ),
-  ],
-  dependencies: [
-    sibling(
-      "SwiftHablare",
-      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
-      from: "5.7.5"
-    ),
-    sibling(
-      "mlx-audio-swift",
-      remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
-      from: "0.5.1"
-    ),
-    sibling(
-      "SwiftAcervo",
-      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-      from: "0.8.4"
-    ),
-    sibling(
-      "SwiftTuberia",
-      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
-      from: "0.6.0"
-    ),
-    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    sibling(
-      "vox-format",
-      remote: "https://github.com/intrusive-memory/vox-format.git",
-      from: "0.3.1"
-    ),
-  ],
-  targets: [
-    .target(
-      name: "SwiftVoxAlta",
-      dependencies: [
-        .product(name: "SwiftHablare", package: "SwiftHablare"),
-        .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
-        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-        .product(name: "Tuberia", package: "SwiftTuberia"),
-        .product(name: "VoxFormat", package: "vox-format"),
-      ],
-      swiftSettings: [
-        .enableUpcomingFeature("StrictConcurrency")
-      ]
-    ),
-    .executableTarget(
-      name: "diga",
-      dependencies: [
-        "SwiftVoxAlta",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-      ],
-      path: "Sources/diga",
-      swiftSettings: [
-        .enableUpcomingFeature("StrictConcurrency")
-      ]
-    ),
-    .testTarget(
-      name: "SwiftVoxAltaTests",
-      dependencies: [
-        "SwiftVoxAlta",
-        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-        .product(name: "Tuberia", package: "SwiftTuberia"),
-        .product(name: "VoxFormat", package: "vox-format"),
-      ],
-      swiftSettings: [
-        .enableUpcomingFeature("StrictConcurrency")
-      ]
-    ),
-    .testTarget(
-      name: "DigaTests",
-      dependencies: [
-        "diga",
-        "SwiftVoxAlta",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-        .product(name: "VoxFormat", package: "vox-format"),
-      ],
-      swiftSettings: [
-        .enableUpcomingFeature("StrictConcurrency")
-      ]
-    ),
-  ]
+    name: "SwiftVoxAlta",
+    platforms: [
+        .macOS(.v26),
+        .iOS(.v26),
+    ],
+    products: [
+        .library(
+            name: "SwiftVoxAlta",
+            targets: ["SwiftVoxAlta"]
+        ),
+        .executable(
+            name: "diga",
+            targets: ["diga"]
+        ),
+    ],
+    dependencies: [
+        sibling(
+            "SwiftHablare",
+            remote: "https://github.com/intrusive-memory/SwiftHablare.git",
+            from: "6.1.0"
+        ),
+        sibling(
+            "mlx-audio-swift",
+            remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
+            from: "0.6.0"
+        ),
+        sibling(
+            "SwiftAcervo",
+            remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+            from: "0.8.4"
+        ),
+        sibling(
+            "SwiftTuberia",
+            remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
+            from: "0.6.0"
+        ),
+        .package(
+            url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
+        sibling(
+            "vox-format",
+            remote: "https://github.com/intrusive-memory/vox-format.git",
+            from: "0.3.1"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SwiftVoxAlta",
+            dependencies: [
+                .product(name: "SwiftHablare", package: "SwiftHablare"),
+                .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
+                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+                .product(name: "Tuberia", package: "SwiftTuberia"),
+                .product(name: "VoxFormat", package: "vox-format"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency")
+            ]
+        ),
+        .executableTarget(
+            name: "diga",
+            dependencies: [
+                "SwiftVoxAlta",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+            ],
+            path: "Sources/diga",
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency")
+            ]
+        ),
+        .testTarget(
+            name: "SwiftVoxAltaTests",
+            dependencies: [
+                "SwiftVoxAlta",
+                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+                .product(name: "Tuberia", package: "SwiftTuberia"),
+                .product(name: "VoxFormat", package: "vox-format"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency")
+            ]
+        ),
+        .testTarget(
+            name: "DigaTests",
+            dependencies: [
+                "diga",
+                "SwiftVoxAlta",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+                .product(name: "VoxFormat", package: "vox-format"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency")
+            ]
+        ),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,108 +10,108 @@ import PackageDescription
 let useLocalSiblings = ProcessInfo.processInfo.environment["CI"] != "true"
 
 func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-    let localPath = "../\(name)"
-    if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-        return .package(path: localPath)
-    }
-    return .package(url: remote, .upToNextMajor(from: version))
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
 }
 
 let package = Package(
-    name: "SwiftVoxAlta",
-    platforms: [
-        .macOS(.v26),
-        .iOS(.v26),
-    ],
-    products: [
-        .library(
-            name: "SwiftVoxAlta",
-            targets: ["SwiftVoxAlta"]
-        ),
-        .executable(
-            name: "diga",
-            targets: ["diga"]
-        ),
-    ],
-    dependencies: [
-        sibling(
-            "SwiftHablare",
-            remote: "https://github.com/intrusive-memory/SwiftHablare.git",
-            from: "6.1.0"
-        ),
-        sibling(
-            "mlx-audio-swift",
-            remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
-            from: "0.6.0"
-        ),
-        sibling(
-            "SwiftAcervo",
-            remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-            from: "0.10.0"
-        ),
-        sibling(
-            "SwiftTuberia",
-            remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
-            from: "0.6.0"
-        ),
-        .package(
-            url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-        sibling(
-            "vox-format",
-            remote: "https://github.com/intrusive-memory/vox-format.git",
-            from: "0.3.1"
-        ),
-    ],
-    targets: [
-        .target(
-            name: "SwiftVoxAlta",
-            dependencies: [
-                .product(name: "SwiftHablare", package: "SwiftHablare"),
-                .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
-                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-                .product(name: "Tuberia", package: "SwiftTuberia"),
-                .product(name: "VoxFormat", package: "vox-format"),
-            ],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency")
-            ]
-        ),
-        .executableTarget(
-            name: "diga",
-            dependencies: [
-                "SwiftVoxAlta",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-            ],
-            path: "Sources/diga",
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency")
-            ]
-        ),
-        .testTarget(
-            name: "SwiftVoxAltaTests",
-            dependencies: [
-                "SwiftVoxAlta",
-                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-                .product(name: "Tuberia", package: "SwiftTuberia"),
-                .product(name: "VoxFormat", package: "vox-format"),
-            ],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency")
-            ]
-        ),
-        .testTarget(
-            name: "DigaTests",
-            dependencies: [
-                "diga",
-                "SwiftVoxAlta",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "SwiftAcervo", package: "SwiftAcervo"),
-                .product(name: "VoxFormat", package: "vox-format"),
-            ],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency")
-            ]
-        ),
-    ]
+  name: "SwiftVoxAlta",
+  platforms: [
+    .macOS(.v26),
+    .iOS(.v26),
+  ],
+  products: [
+    .library(
+      name: "SwiftVoxAlta",
+      targets: ["SwiftVoxAlta"]
+    ),
+    .executable(
+      name: "diga",
+      targets: ["diga"]
+    ),
+  ],
+  dependencies: [
+    sibling(
+      "SwiftHablare",
+      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
+      from: "6.1.0"
+    ),
+    sibling(
+      "mlx-audio-swift",
+      remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
+      from: "0.6.0"
+    ),
+    sibling(
+      "SwiftAcervo",
+      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+      from: "0.11.0"
+    ),
+    sibling(
+      "SwiftTuberia",
+      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
+      from: "0.6.2"
+    ),
+    .package(
+      url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
+    sibling(
+      "vox-format",
+      remote: "https://github.com/intrusive-memory/vox-format.git",
+      from: "0.3.1"
+    ),
+  ],
+  targets: [
+    .target(
+      name: "SwiftVoxAlta",
+      dependencies: [
+        .product(name: "SwiftHablare", package: "SwiftHablare"),
+        .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
+        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+        .product(name: "Tuberia", package: "SwiftTuberia"),
+        .product(name: "VoxFormat", package: "vox-format"),
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("StrictConcurrency")
+      ]
+    ),
+    .executableTarget(
+      name: "diga",
+      dependencies: [
+        "SwiftVoxAlta",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+      ],
+      path: "Sources/diga",
+      swiftSettings: [
+        .enableUpcomingFeature("StrictConcurrency")
+      ]
+    ),
+    .testTarget(
+      name: "SwiftVoxAltaTests",
+      dependencies: [
+        "SwiftVoxAlta",
+        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+        .product(name: "Tuberia", package: "SwiftTuberia"),
+        .product(name: "VoxFormat", package: "vox-format"),
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("StrictConcurrency")
+      ]
+    ),
+    .testTarget(
+      name: "DigaTests",
+      dependencies: [
+        "diga",
+        "SwiftVoxAlta",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "SwiftAcervo", package: "SwiftAcervo"),
+        .product(name: "VoxFormat", package: "vox-format"),
+      ],
+      swiftSettings: [
+        .enableUpcomingFeature("StrictConcurrency")
+      ]
+    ),
+  ]
 )

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew install diga
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.10.1")
+    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.10.2")
 ]
 ```
 

--- a/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
@@ -106,18 +106,12 @@ public enum Qwen3TTSModelSize {
 extension Qwen3TTSModelRepo {
   /// The Acervo component ID for this model variant.
   ///
-  /// Used to look up, download, and check availability of this model
-  /// via the SwiftAcervo Component Registry.
+  /// Equal to `Acervo.slugify(rawValue)`, which is also the CDN slug under which
+  /// the model's manifest is served (`<R2_PUBLIC_URL>/models/<slug>/manifest.json`).
+  /// Keeping component ID == slugified repo ID == CDN slug eliminates triple-naming
+  /// between SwiftVoxAlta, mlx-audio-swift, and the CDN.
   public var componentId: String {
-    switch self {
-    case .base1_7B: return "qwen3-tts-base-1.7b"
-    case .base0_6B: return "qwen3-tts-base-0.6b"
-    case .customVoice1_7B: return "qwen3-tts-custom-1.7b"
-    case .customVoice0_6B: return "qwen3-tts-custom-0.6b"
-    case .voiceDesign1_7B: return "qwen3-tts-voicedesign-1.7b"
-    case .base1_7B_8bit: return "qwen3-tts-base-1.7b-8bit"
-    case .base1_7B_4bit: return "qwen3-tts-base-1.7b-4bit"
-    }
+    Acervo.slugify(rawValue)
   }
 }
 
@@ -330,7 +324,10 @@ public actor VoxAltaModelManager {
         // The async load must run outside this sync closure.
         ()
       }
-      return try await TTSModelUtils.loadModel(modelRepo: repo)
+      // Explicit modelType avoids mlx-audio-swift's inferModelType, which checks
+      // for "qwen3_tts" (underscore) but the HF repo uses "qwen3-tts" (hyphen)
+      // and would mis-route to the non-TTS Qwen3 LLM path.
+      return try await TTSModelUtils.loadModel(modelRepo: repo, modelType: "qwen3_tts")
     } catch let error as AcervoError {
       switch error {
       case .modelNotFound(let id):

--- a/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
@@ -214,6 +214,38 @@ public actor VoxAltaModelManager {
   /// The repository identifier of the currently loaded model.
   private var _currentModelRepo: String?
 
+  /// Wrapper that lets a non-Sendable `SpeechGenerationModel` cross the
+  /// nonisolated `Task` boundary used for single-flight load coordination.
+  /// The model is only ever observed from inside this actor, so unchecked
+  /// Sendable is safe.
+  private struct LoadedModelBox: @unchecked Sendable {
+    let model: any SpeechGenerationModel
+  }
+
+  /// In-flight load coordination. Concurrent callers requesting the same
+  /// repo await this Task instead of each starting their own load.
+  ///
+  /// Without this, actor reentrancy across the awaits inside `loadModel`
+  /// (e.g. `Acervo.ensureComponentReady`) lets every concurrent caller pass
+  /// the cache check before any one finishes, multiplying the model's memory
+  /// footprint by N. With N envelope-driven calls each mmapping a ~4 GB
+  /// model, virtual footprint reaches tens of GB and the OS reclaims us.
+  private var inFlightLoad: (repo: String, task: Task<LoadedModelBox, Error>)?
+
+  /// Number of times `_performLoad` has actually executed. Used by tests to
+  /// verify that concurrent `loadModel` calls coalesce onto one underlying
+  /// load rather than each running their own.
+  internal private(set) var performLoadInvocationCount: Int = 0
+
+  /// Test-only helper. Wraps `loadModel(repo:)` and discards the non-Sendable
+  /// result inside this actor's isolation, exposing only the success/throw to
+  /// nonisolated callers. Tests use this to drive concurrent loads without
+  /// having to import MLXAudioTTS just to satisfy Sendable on `any
+  /// SpeechGenerationModel`.
+  internal func _loadModelDiscardingResult(repo: String) async throws {
+    _ = try await loadModel(repo: repo)
+  }
+
   // MARK: - Public API
 
   /// Whether a model is currently loaded and cached.
@@ -363,13 +395,56 @@ public actor VoxAltaModelManager {
   /// - Returns: The loaded `SpeechGenerationModel` instance.
   /// - Throws: `VoxAltaError.modelNotAvailable` if loading fails.
   public func loadModel(repo: String) async throws -> any SpeechGenerationModel {
-    // One-time migration from legacy cache to Acervo shared directory
-    migrateIfNeeded()
-
-    // Return cached model if same repo is requested
+    // Cache hit: same repo, already loaded.
     if let cached = cachedModel, _currentModelRepo == repo {
       return cached
     }
+
+    // Coalesce concurrent callers requesting the same repo onto a single
+    // in-flight load. See `inFlightLoad` for the rationale.
+    if let inFlight = inFlightLoad, inFlight.repo == repo {
+      return try await inFlight.task.value.model
+    }
+
+    let loadTask = Task<LoadedModelBox, Error> { [weak self] in
+      guard let self = self else {
+        throw VoxAltaError.modelNotAvailable("VoxAltaModelManager deallocated during load")
+      }
+      return try await self._performLoad(repo: repo)
+    }
+    inFlightLoad = (repo: repo, task: loadTask)
+
+    do {
+      let model = try await loadTask.value.model
+      cachedModel = model
+      _currentModelRepo = repo
+      inFlightLoad = nil
+
+      // Log Neural Accelerator status on M5
+      let generation = AppleSiliconGeneration.current
+      if generation.hasNeuralAccelerators {
+        FileHandle.standardError.write(
+          Data(
+            "Neural Accelerators detected (\(generation.rawValue)) - MLX will auto-accelerate TTS inference (4× speedup on macOS 26.2+)\n"
+              .utf8
+          ))
+      }
+      return model
+    } catch {
+      inFlightLoad = nil
+      throw error
+    }
+  }
+
+  /// Runs the actual model load. Extracted from `loadModel(repo:)` so the
+  /// load body can run inside a single-flight `Task` that coalesces
+  /// concurrent callers. Returns a `LoadedModelBox` so the result can cross
+  /// the nonisolated Task boundary (the model itself is non-Sendable).
+  private func _performLoad(repo: String) async throws -> LoadedModelBox {
+    performLoadInvocationCount += 1
+
+    // One-time migration from legacy cache to Acervo shared directory
+    migrateIfNeeded()
 
     // Unload current model if switching repos
     if cachedModel != nil {
@@ -392,7 +467,6 @@ public actor VoxAltaModelManager {
     }
 
     // Step 1: Ensure the model's files are downloaded via Acervo Component Registry.
-    // This happens outside the validation closure since download may be expensive.
     try await Acervo.ensureComponentReady(componentId)
 
     // Step 2: Load the model with v2 access patterns (file presence and checksums validated).
@@ -400,22 +474,7 @@ public actor VoxAltaModelManager {
       componentId: componentId,
       repo: repo
     )
-
-    // Cache the loaded model
-    cachedModel = model
-    _currentModelRepo = repo
-
-    // Log Neural Accelerator status on M5
-    let generation = AppleSiliconGeneration.current
-    if generation.hasNeuralAccelerators {
-      FileHandle.standardError.write(
-        Data(
-          "Neural Accelerators detected (\(generation.rawValue)) - MLX will auto-accelerate TTS inference (4× speedup on macOS 26.2+)\n"
-            .utf8
-        ))
-    }
-
-    return model
+    return LoadedModelBox(model: model)
   }
 
   /// Loads a model using a well-known `Qwen3TTSModelRepo` enum case.

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -29,7 +29,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.10.1"
+  public static let version = "0.10.2"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.10.1"
+  static let current = "0.10.2"
 }

--- a/Tests/SwiftVoxAltaTests/ComponentDescriptorRegistrationTests.swift
+++ b/Tests/SwiftVoxAltaTests/ComponentDescriptorRegistrationTests.swift
@@ -43,7 +43,7 @@ struct ComponentDescriptorRegistrationTests {
   func base17BMemoryBudgetMatchesExpectation() throws {
     _ = VoxAltaModelManager()
 
-    let descriptor = try #require(Acervo.component("qwen3-tts-base-1.7b"))
+    let descriptor = try #require(Acervo.component(Qwen3TTSModelRepo.base1_7B.componentId))
 
     #expect(descriptor.minimumMemoryBytes == 3_400_000_000)
     #expect(descriptor.metadata["deprecated"] != "true")
@@ -53,7 +53,7 @@ struct ComponentDescriptorRegistrationTests {
   func deprecatedVariantFlagged() throws {
     _ = VoxAltaModelManager()
 
-    let descriptor = try #require(Acervo.component("qwen3-tts-base-1.7b-4bit"))
+    let descriptor = try #require(Acervo.component(Qwen3TTSModelRepo.base1_7B_4bit.componentId))
 
     #expect(descriptor.metadata["deprecated"] == "true")
     #expect(descriptor.displayName.contains("Deprecated"))

--- a/Tests/SwiftVoxAltaTests/VoxAltaModelManagerSingleFlightTests.swift
+++ b/Tests/SwiftVoxAltaTests/VoxAltaModelManagerSingleFlightTests.swift
@@ -1,0 +1,115 @@
+//
+//  VoxAltaModelManagerSingleFlightTests.swift
+//  SwiftVoxAltaTests
+//
+//  Regression test for the single-flight `loadModel` coalescing guard.
+//
+//  Background: `VoxAltaModelManager` is a Swift actor, but actors are
+//  reentrant across `await` points. Without an explicit single-flight
+//  guard, N concurrent callers can each pass the cache check before any
+//  one finishes loading, then each independently mmap a multi-GB model.
+//  Observed in practice: 24 concurrent envelope-driven calls × ~4 GB =
+//  ~96 GB virtual footprint before macOS reclaim killed the process.
+//
+
+import Foundation
+import Testing
+
+@testable import SwiftVoxAlta
+
+@Suite("VoxAltaModelManager — Single-flight loadModel")
+struct VoxAltaModelManagerSingleFlightTests {
+
+  /// Concurrent `loadModel` calls for the same repo must coalesce onto a
+  /// single underlying load. We use a repo string that isn't a recognised
+  /// `Qwen3TTSModelRepo` so the load throws fast (no model files touched);
+  /// the assertion is on `performLoadInvocationCount`, which must stay at 1.
+  @Test("Concurrent loadModel calls coalesce onto one underlying load")
+  func concurrentLoadsCoalesce() async throws {
+    let manager = VoxAltaModelManager()
+    let unknownRepo = "test-only-unknown-repo-not-a-real-Qwen3TTSModelRepo"
+
+    let concurrency = 16
+    let results: [Result<Void, any Error>] = await withTaskGroup(
+      of: Result<Void, any Error>.self
+    ) { group in
+      for _ in 0..<concurrency {
+        group.addTask {
+          do {
+            try await manager._loadModelDiscardingResult(repo: unknownRepo)
+            return .success(())
+          } catch {
+            return .failure(error)
+          }
+        }
+      }
+      var collected: [Result<Void, any Error>] = []
+      for await result in group {
+        collected.append(result)
+      }
+      return collected
+    }
+
+    // Every concurrent caller must receive the load's error — none should
+    // hang and none should silently succeed against an unknown repo.
+    #expect(results.count == concurrency)
+    let failures = results.compactMap { result -> (any Error)? in
+      if case .failure(let error) = result { return error }
+      return nil
+    }
+    #expect(failures.count == concurrency, "All concurrent calls should fail with the same error")
+    for error in failures {
+      guard let voxError = error as? VoxAltaError else {
+        Issue.record("Expected VoxAltaError, got \(type(of: error))")
+        continue
+      }
+      if case .modelNotAvailable = voxError {
+        // Expected
+      } else {
+        Issue.record("Expected modelNotAvailable, got \(voxError)")
+      }
+    }
+
+    // The core regression assertion: only one underlying load ran.
+    let invocations = await manager.performLoadInvocationCount
+    #expect(
+      invocations == 1,
+      "Expected single-flight: 1 _performLoad invocation for \(concurrency) concurrent calls, got \(invocations)"
+    )
+  }
+
+  /// After a failed load completes and clears `inFlightLoad`, a subsequent
+  /// call must be free to start a fresh load. This guards against the fix
+  /// over-coalescing across distinct retry boundaries.
+  @Test("Failed load clears in-flight state so next call retries")
+  func failedLoadClearsState() async throws {
+    let manager = VoxAltaModelManager()
+    let unknownRepo = "test-only-unknown-repo-not-a-real-Qwen3TTSModelRepo"
+
+    // First call: fails.
+    do {
+      try await manager._loadModelDiscardingResult(repo: unknownRepo)
+      Issue.record("Expected first call to throw")
+    } catch {
+      // Expected
+    }
+
+    let firstCount = await manager.performLoadInvocationCount
+    #expect(firstCount == 1)
+
+    // Second call (sequential, after first fully returned): must run a
+    // fresh load — not see a stale in-flight task or a stale cache hit.
+    do {
+      try await manager._loadModelDiscardingResult(repo: unknownRepo)
+      Issue.record("Expected second call to throw")
+    } catch {
+      // Expected
+    }
+
+    let secondCount = await manager.performLoadInvocationCount
+    #expect(
+      secondCount == 2,
+      "Sequential failed loads should each invoke _performLoad; got \(secondCount)"
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- version bump dependencies
- Fix actor-reentrancy stampede in VoxAltaModelManager.loadModel
- deps: bump SwiftAcervo floor to 0.10.0

## Test plan
- [ ] `make test-unit` (fast iteration)
- [ ] `make test` (incl. integration tests)
- [ ] Verify Qwen3-TTS load path under concurrent loadModel callers (actor-reentrancy fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)