### PR TITLE
ci: export ACERVO_APP_GROUP_ID for SwiftAcervo v0.10.0

### DIFF
--- a/.github/workflows/ensure-model-cdn.yml
+++ b/.github/workflows/ensure-model-cdn.yml
@@ -16,6 +16,9 @@ on:
     - cron: '0 0 * * *'  # Midnight UTC
   workflow_dispatch:
 
+env:
+  ACERVO_APP_GROUP_ID: group.intrusive-memory.models
+
 jobs:
   ensure-model-cdn:
     name: Upload Model to CDN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 env:
   BINARY_NAME: diga
   SCHEME: diga
+  ACERVO_APP_GROUP_ID: group.intrusive-memory.models
 
 jobs:
   build-and-release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, development]
 
+env:
+  ACERVO_APP_GROUP_ID: group.intrusive-memory.models
+
 jobs:
   # Fast unit tests (no binary or model downloads required)
   unit-tests:


### PR DESCRIPTION
## Summary

- Adds workflow-level `env: ACERVO_APP_GROUP_ID: group.intrusive-memory.models` to `tests.yml` (new top-level env block after `on:`)
- Extends existing top-level `env:` block in `release.yml` with `ACERVO_APP_GROUP_ID` (no duplicate block created)
- Adds workflow-level `env: ACERVO_APP_GROUP_ID: group.intrusive-memory.models` to `ensure-model-cdn.yml` (new top-level env block after `on:`)

This exports the App Group identifier required by SwiftAcervo v0.10.0 across all three CI workflows so that `Acervo.component(id:)` can resolve the correct App Group container at runtime during tests and releases.

## Test plan

- [ ] CI `Tests` workflow passes on this PR with no `fatalError: SwiftAcervo: no App Group identifier configured`
- [ ] `grep "ACERVO_APP_GROUP_ID" .github/workflows/tests.yml` matches
- [ ] `grep "ACERVO_APP_GROUP_ID" .github/workflows/release.yml` matches
- [ ] `grep "ACERVO_APP_GROUP_ID" .github/workflows/ensure-model-cdn.yml` matches
- [ ] `grep -c "^env:" .github/workflows/release.yml` returns exactly 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)