### PR TITLE
docs: document ACERVO_APP_GROUP_ID; correct stale fallback claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,21 @@ The pipeline is: `echada cast` creates a `.vox` file -> `diga --import-vox voice
 
 ---
 
+## App Group configuration (required)
+
+This package depends on [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) for shared model storage. SwiftAcervo v0.10.0 resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. There is **no silent fallback**.
+
+- **Signed UI apps (macOS / iOS)**: declare `com.apple.security.application-groups` with `group.intrusive-memory.models` in your `.entitlements` file. iOS apps additionally need `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the launch environment.
+- **CLI tools, scripts, CI jobs, test runners**: export `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the shell or job environment. The standard place is `~/.zprofile`:
+
+    ```sh
+    export ACERVO_APP_GROUP_ID=group.intrusive-memory.models
+    ```
+
+Without this, `Acervo.sharedModelsDirectory` traps with `fatalError`. See [SwiftAcervo's USAGE.md](https://github.com/intrusive-memory/SwiftAcervo/blob/main/USAGE.md) for full details.
+
+---
+
 ## Build and Test
 
 **CRITICAL**: Use `xcodebuild` or the Makefile. Metal shaders required by Qwen3-TTS do not compile with `swift build`.
@@ -591,19 +606,33 @@ diga -v voice.vox "Hello, world!"      # Synthesize directly (no import needed)
 └── mlx-community_Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16/  (~4.3GB, preset speakers)
 ```
 
-### App Group entitlement (REQUIRED for app integrators)
+### App Group / ACERVO_APP_GROUP_ID (REQUIRED for all integrators)
 
-The `~/Library/SharedModels/` path above is the App Group container `group.intrusive-memory.models`. **Every app target that links SwiftVoxAlta (or any SwiftAcervo consumer) must enable this App Group capability.** Without it, SwiftAcervo silently falls back to `~/Library/Application Support/SwiftAcervo/SharedModels/` — a per-app path that is not shared across apps, defeating the cross-app caching that is the whole point of the shared-models layout.
+The `~/Library/SharedModels/` path above is the App Group container `group.intrusive-memory.models`. SwiftAcervo v0.10.0 resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. **There is no silent fallback.** If neither source is configured, `Acervo.sharedModelsDirectory` calls `fatalError` and the process traps immediately.
 
-Xcode setup (per target, including extensions):
+#### Signed UI apps (macOS / iOS)
+
+Every app target that links SwiftVoxAlta (or any SwiftAcervo consumer) must enable the App Group capability:
 
 1. Target → **Signing & Capabilities** → **+ Capability** → **App Groups**.
 2. Check or add `group.intrusive-memory.models`.
 3. Rebuild.
 
-Verify at runtime by printing `Acervo.sharedModelsDirectory`. A correctly entitled app shows a path under `~/Library/Group Containers/group.intrusive-memory.models/...`. A path ending in `Application Support/SwiftAcervo/SharedModels` means the entitlement is missing.
+iOS apps additionally need `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the launch environment (the entitlement alone is not sufficient on iOS).
 
-The `diga` CLI in this repo is unsigned and can't join App Groups — it uses the fallback path by design. This caveat is library-consumer's only; nothing in SwiftVoxAlta itself needs the entitlement. See [SwiftAcervo USAGE.md](https://github.com/intrusive-memory/SwiftAcervo/blob/main/USAGE.md) for the full integration checklist.
+Verify at runtime by printing `Acervo.sharedModelsDirectory`. A correctly entitled app shows a path under `~/Library/Group Containers/group.intrusive-memory.models/...`.
+
+#### CLI tools, scripts, CI jobs, test runners
+
+Unsigned binaries (including the `diga` CLI in this repo), scripts, CI jobs, and Swift test runners cannot join an App Group via entitlement. These processes must export `ACERVO_APP_GROUP_ID` instead:
+
+```sh
+export ACERVO_APP_GROUP_ID=group.intrusive-memory.models
+```
+
+The standard place for developer machines is `~/.zprofile`. For CI, set it as a job-level environment variable. Without this export, `diga` and any test that exercises a SwiftAcervo path will trap with `fatalError` at the point `Acervo.sharedModelsDirectory` is first accessed.
+
+See [SwiftAcervo USAGE.md](https://github.com/intrusive-memory/SwiftAcervo/blob/main/USAGE.md) for the full integration checklist.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,4 @@ make test              # ~15-60 seconds, includes integration tests
 - CLI commands and voice management
 - Architecture patterns and design decisions
 - Integration guides for SwiftHablare/Produciesta
+- **App Group / `ACERVO_APP_GROUP_ID` configuration (required)** — see the "App Group configuration (required)" section

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,3 +41,4 @@ swift test
 - CLI commands and voice management
 - Architecture patterns and design decisions
 - Integration guides for SwiftHablare/Produciesta
+- **App Group / `ACERVO_APP_GROUP_ID` configuration (required)** — see the "App Group configuration (required)" section

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ For detailed integration instructions, see **[Produciesta Integration Guide](doc
 - [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) -- Shared model management and caching
 - [vox-format](https://github.com/intrusive-memory/vox-format) -- Portable `.vox` voice identity file format
 
+## App Group configuration (required)
+
+This package depends on [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) for shared model storage. SwiftAcervo v0.10.0 resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. There is **no silent fallback**.
+
+- **Signed UI apps (macOS / iOS)**: declare `com.apple.security.application-groups` with `group.intrusive-memory.models` in your `.entitlements` file. iOS apps additionally need `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the launch environment.
+- **CLI tools, scripts, CI jobs, test runners**: export `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the shell or job environment. The standard place is `~/.zprofile`:
+
+    ```sh
+    export ACERVO_APP_GROUP_ID=group.intrusive-memory.models
+    ```
+
+Without this, `Acervo.sharedModelsDirectory` traps with `fatalError`. See [SwiftAcervo's USAGE.md](https://github.com/intrusive-memory/SwiftAcervo/blob/main/USAGE.md) for full details.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Appends the canonical `## App Group configuration (required)` snippet (verbatim from `ACERVO_CONSUMERS.md`) to both `README.md` and `AGENTS.md`.
- Fixes two factually incorrect claims in `AGENTS.md` that contradicted the v0.10.0 contract: "fallback is silent" and "uses the fallback path by design". SwiftAcervo v0.10.0 calls `fatalError` if neither `ACERVO_APP_GROUP_ID` env var nor `com.apple.security.application-groups` entitlement is configured — there is no silent fallback.
- Expands the App Group section in `AGENTS.md` to cover CLI tools, scripts, CI jobs, and test runners (must export `ACERVO_APP_GROUP_ID`; cannot use the entitlement path since they are unsigned).
- Updates `CLAUDE.md` and `GEMINI.md` with an explicit pointer to the "App Group configuration (required)" section in `AGENTS.md`.

## Test plan

- [ ] `grep "ACERVO_APP_GROUP_ID" README.md AGENTS.md` matches in both files.
- [ ] `grep -i "fallback is silent\|fallback path by design" AGENTS.md` returns no matches.
- [ ] No changes to `Sources/` or `Tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)