### PR TITLE
Development → Main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.10.4
+**Current Version**: 0.10.4-dev
 
 ---
 
@@ -121,7 +121,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.10.4)
+│       ├── Version.swift              # Version constant (0.10.4-dev)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)
@@ -171,7 +171,7 @@ Implements SwiftHablare's `VoiceProvider` protocol with dual-mode routing.
 
 ```swift
 public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
-    public static let version = "0.10.4"
+    public static let version = "0.10.4-dev"
 
     // VoiceProvider protocol properties
     public let providerId = "voxalta"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.10.4-dev
+**Current Version**: 0.10.5
 
 ---
 
@@ -121,7 +121,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.10.4-dev)
+│       ├── Version.swift              # Version constant (0.10.5)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)
@@ -171,7 +171,7 @@ Implements SwiftHablare's `VoiceProvider` protocol with dual-mode routing.
 
 ```swift
 public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
-    public static let version = "0.10.4-dev"
+    public static let version = "0.10.5"
 
     // VoiceProvider protocol properties
     public let providerId = "voxalta"

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
     sibling(
       "mlx-audio-swift",
       remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
-      from: "0.6.6"),
+      from: "0.7.0"),
     sibling(
       "SwiftAcervo",
       remote: "https://github.com/intrusive-memory/SwiftAcervo.git",

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,6 @@
 // swift-tools-version: 6.2
 
-import Foundation
 import PackageDescription
-
-// In CI we always pin to released remotes. Locally, prefer a sibling checkout
-// at ../<name> if present so in-flight changes can be exercised end-to-end
-// without publishing a release. Falls back to the remote pin if the sibling
-// directory is missing, so fresh clones still build.
-//
-// When this manifest is evaluated as a transitive dependency inside Xcode's
-// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
-// dependency lives as a sibling in the same directory. Treating those as
-// in-development local paths produces conflicting package identities, so we
-// must skip the sibling shortcut in that context.
-let manifestDir = (#filePath as NSString).deletingLastPathComponent
-let isSPMCheckout =
-  manifestDir.contains("/SourcePackages/checkouts/")
-  || manifestDir.contains("/.build/checkouts/")
-let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
-let useLocalSiblings = !isCI && !isSPMCheckout
-
-func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
-}
-
-/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
-/// remote branch when no local sibling exists. Use only when a temporary
-/// pre-release dependency on a feature branch is required; switch back to the
-/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
-func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, branch: branch)
-}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -57,28 +19,18 @@ let package = Package(
     ),
   ],
   dependencies: [
-    sibling(
-      "SwiftHablare",
-      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
-      from: "6.1.0"),
-    sibling(
-      "mlx-audio-swift",
-      remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
-      from: "0.7.0"),
-    sibling(
-      "SwiftAcervo",
-      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-      from: "0.12.0"),
-    sibling(
-      "SwiftTuberia",
-      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
-      from: "0.6.5"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.0")),
+    .package(
+      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.7.0")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.12.0")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.6.5")),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    sibling(
-      "vox-format",
-      remote: "https://github.com/intrusive-memory/vox-format.git",
-      from: "0.3.1"),
+    .package(
+      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -19,18 +57,28 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.0")),
-    .package(
-      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.6.6")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.12.0")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.6.5")),
+    sibling(
+      "SwiftHablare",
+      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
+      from: "6.1.0"),
+    sibling(
+      "mlx-audio-swift",
+      remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
+      from: "0.6.6"),
+    sibling(
+      "SwiftAcervo",
+      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+      from: "0.12.0"),
+    sibling(
+      "SwiftTuberia",
+      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
+      from: "0.6.5"),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
+    sibling(
+      "vox-format",
+      remote: "https://github.com/intrusive-memory/vox-format.git",
+      from: "0.3.1"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew install diga
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.10.4")
+    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.10.5")
 ]
 ```
 

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -29,7 +29,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.10.4-dev"
+  public static let version = "0.10.5"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -29,7 +29,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.10.4"
+  public static let version = "0.10.4-dev"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.10.4"
+  static let current = "0.10.4-dev"
 }

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.10.4-dev"
+  static let current = "0.10.5"
 }


### PR DESCRIPTION
## Next Development Cycle

Development branch is synced with main after the v0.10.4 release and marked as `0.10.4-dev`. The `sibling(...)` helper has been restored in `Package.swift` so cross-library local checkouts at `../<name>` are picked up automatically during development.

This PR is in draft mode and will collect changes for the next release. The `-dev` suffix will be stripped when the next version is bumped.

### v0.10.4 highlights
- Telemetry instrumentation (OPERATION LEAKING STETHOSCOPE)
- SwiftAcervo 0.11.1 → 0.12.0
- SwiftTuberia 0.6.3 → 0.6.5