### PR TITLE
Development → Main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.10.5-dev
+**Current Version**: 0.10.6
 
 ---
 
@@ -121,7 +121,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.10.5-dev)
+│       ├── Version.swift              # Version constant (0.10.6)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)
@@ -171,7 +171,7 @@ Implements SwiftHablare's `VoiceProvider` protocol with dual-mode routing.
 
 ```swift
 public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
-    public static let version = "0.10.5-dev"
+    public static let version = "0.10.6"
 
     // VoiceProvider protocol properties
     public let providerId = "voxalta"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.10.5
+**Current Version**: 0.10.5-dev
 
 ---
 
@@ -121,7 +121,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.10.5)
+│       ├── Version.swift              # Version constant (0.10.5-dev)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)
@@ -171,7 +171,7 @@ Implements SwiftHablare's `VoiceProvider` protocol with dual-mode routing.
 
 ```swift
 public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
-    public static let version = "0.10.5"
+    public static let version = "0.10.5-dev"
 
     // VoiceProvider protocol properties
     public let providerId = "voxalta"

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,6 @@
 // swift-tools-version: 6.2
 
-import Foundation
 import PackageDescription
-
-// In CI we always pin to released remotes. Locally, prefer a sibling checkout
-// at ../<name> if present so in-flight changes can be exercised end-to-end
-// without publishing a release. Falls back to the remote pin if the sibling
-// directory is missing, so fresh clones still build.
-//
-// When this manifest is evaluated as a transitive dependency inside Xcode's
-// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
-// dependency lives as a sibling in the same directory. Treating those as
-// in-development local paths produces conflicting package identities, so we
-// must skip the sibling shortcut in that context.
-let manifestDir = (#filePath as NSString).deletingLastPathComponent
-let isSPMCheckout =
-  manifestDir.contains("/SourcePackages/checkouts/")
-  || manifestDir.contains("/.build/checkouts/")
-let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
-let useLocalSiblings = !isCI && !isSPMCheckout
-
-func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
-}
-
-/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
-/// remote branch when no local sibling exists. Use only when a temporary
-/// pre-release dependency on a feature branch is required; switch back to the
-/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
-func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, branch: branch)
-}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -57,28 +19,18 @@ let package = Package(
     ),
   ],
   dependencies: [
-    sibling(
-      "SwiftHablare",
-      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
-      from: "6.1.0"),
-    sibling(
-      "mlx-audio-swift",
-      remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
-      from: "0.7.0"),
-    sibling(
-      "SwiftAcervo",
-      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-      from: "0.12.0"),
-    sibling(
-      "SwiftTuberia",
-      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
-      from: "0.6.5"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.1")),
+    .package(
+      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.8.0")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.12.0")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.6.5")),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    sibling(
-      "vox-format",
-      remote: "https://github.com/intrusive-memory/vox-format.git",
-      from: "0.3.1"),
+    .package(
+      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -86,6 +86,7 @@ let package = Package(
       dependencies: [
         .product(name: "SwiftHablare", package: "SwiftHablare"),
         .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
+        .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
         .product(name: "SwiftAcervo", package: "SwiftAcervo"),
         .product(name: "Tuberia", package: "SwiftTuberia"),
         .product(name: "VoxFormat", package: "vox-format"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -19,18 +57,28 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.0")),
-    .package(
-      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMajor(from: "0.7.0")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.12.0")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.6.5")),
+    sibling(
+      "SwiftHablare",
+      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
+      from: "6.1.0"),
+    sibling(
+      "mlx-audio-swift",
+      remote: "https://github.com/intrusive-memory/mlx-audio-swift.git",
+      from: "0.7.0"),
+    sibling(
+      "SwiftAcervo",
+      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+      from: "0.12.0"),
+    sibling(
+      "SwiftTuberia",
+      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
+      from: "0.6.5"),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
+    sibling(
+      "vox-format",
+      remote: "https://github.com/intrusive-memory/vox-format.git",
+      from: "0.3.1"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew install diga
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.10.5")
+    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.10.6")
 ]
 ```
 

--- a/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MLX
+import MLXAudioCore
 import MLXAudioTTS
 import SwiftAcervo
 import Tuberia
@@ -423,6 +424,7 @@ public actor VoxAltaModelManager {
       cachedModel = model
       _currentModelRepo = repo
       inFlightLoad = nil
+      applyMLXTelemetryToCachedModel()
 
       // Log Neural Accelerator status on M5
       let generation = AppleSiliconGeneration.current
@@ -623,9 +625,31 @@ public actor VoxAltaModelManager {
   /// A nil reporter is a no-op — `capture` never blocks the caller.
   private var telemetry: (any VoxAltaTelemetryReporter)?
 
+  /// Optional MLXAudio reporter forwarded to the active Qwen3TTS model.
+  /// Distinct from `telemetry` (VoxAlta-level events).
+  private var mlxAudioTelemetry: (any MLXAudioTelemetryReporter)?
+
   /// Attaches or detaches a telemetry reporter. Pass `nil` to disable.
   public func setTelemetry(_ reporter: (any VoxAltaTelemetryReporter)?) {
     self.telemetry = reporter
+  }
+
+  /// Attaches or detaches an MLXAudio telemetry reporter. Applied immediately
+  /// to any currently-cached model, and to every model loaded thereafter.
+  public func setMLXTelemetry(_ reporter: (any MLXAudioTelemetryReporter)?) {
+    self.mlxAudioTelemetry = reporter
+    if let qwenModel = cachedModel as? Qwen3TTSModel {
+      qwenModel.setTelemetry(reporter)
+    }
+  }
+
+  /// Applies the current MLXAudio reporter (if any) to a freshly loaded model.
+  /// Called from `loadModel(repo:)` after `cachedModel` is bound.
+  private func applyMLXTelemetryToCachedModel() {
+    guard let reporter = mlxAudioTelemetry,
+      let qwenModel = cachedModel as? Qwen3TTSModel
+    else { return }
+    qwenModel.setTelemetry(reporter)
   }
 
   /// Forwards a telemetry event to the attached reporter, if any.

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -29,7 +29,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.10.5"
+  public static let version = "0.10.5-dev"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 @preconcurrency import MLX
+@preconcurrency import MLXAudioCore
 @preconcurrency import MLXAudioTTS
 @preconcurrency import MLXLMCommon
 import SwiftHablare
@@ -423,6 +424,13 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   /// `VoxAltaModelManager`, which owns the reporter reference.
   public func setTelemetry(_ reporter: (any VoxAltaTelemetryReporter)?) async {
     await modelManager.setTelemetry(reporter)
+  }
+
+  /// Attaches or detaches an MLXAudio telemetry reporter, forwarding it to the
+  /// underlying mlx-audio TTS model so MLX-level events (model load, generate
+  /// step, decoder, codec) flow up to the host.
+  public func setMLXTelemetry(_ reporter: (any MLXAudioTelemetryReporter)?) async {
+    await modelManager.setMLXTelemetry(reporter)
   }
 
   /// Forwards a telemetry event through the model manager's reporter.

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -30,7 +30,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.10.5-dev"
+  public static let version = "0.10.6"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.10.5-dev"
+  static let current = "0.10.6"
 }

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.10.5"
+  static let current = "0.10.5-dev"
 }


### PR DESCRIPTION
## Summary

- Add MLXAudio telemetry passthrough so hosts (e.g. Produciesta) can forward an `MLXAudioTelemetryReporter` through `VoxAltaVoiceProvider` down to the underlying `Qwen3TTSModel`.
- The provider is a pure forwarder; `VoxAltaModelManager` stores the reporter and applies it both to the currently-cached model and to every subsequent load.
- Adds `MLXAudioCore` as a product dependency on the `SwiftVoxAlta` target so the protocol can be named directly.

## Why

Produciesta's `GenerationOrchestrator` already calls `voxProvider.setMLXTelemetry(...)`, but the method did not exist on VoxAlta `0.10.5-dev` and the call failed to compile against this package. This unblocks complete telemetry coverage in Produciesta.

## Test plan

- [x] `make build` — builds clean against the new `MLXAudioCore` dep.
- [x] `make test` — DigaTests + Diga Binary Integration Tests pass.
- [x] End-to-end smoke: `./bin/diga --voice ryan -o /tmp/voxalta_telemetry_test.wav "..."` produces a valid 24 kHz / 16-bit / mono WAV; played back in QuickTime Player.
- [ ] Follow-up: dedicated unit test that attaches a stub `MLXAudioTelemetryReporter`, drives a generation, and asserts MLX events are captured. Not blocking — the existing `setTelemetry` pattern this mirrors is already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)