### PR TITLE
fix: Complete version bump to 0.10.9 (diga CLI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ SwiftVoxAlta/
 │       ├── DigaCommand.swift          # CLI entry point (@main, ArgumentParser)
 │       ├── DigaEngine.swift           # Synthesis orchestrator (text -> chunked WAV)
 │       ├── TextChunker.swift          # Sentence-boundary chunking (NLTokenizer)
-│       ├── Version.swift              # Version constant (0.10.8-dev)
+│       ├── Version.swift              # Version constant (0.10.9)
 │       └── VoiceStore.swift           # Persistent custom voice storage (~/.diga/voices/)
 ├── Tests/
 │   ├── SwiftVoxAltaTests/             # 11 test files (library)

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.10.8-dev"
+  static let current = "0.10.9"
 }


### PR DESCRIPTION
Completes the version bump by updating the diga CLI version constant that was missed in PR #39.

This is a trivial string update with no code changes.