### PR TITLE
Release v0.11.2: SwiftAcervo 0.16 migration and routine dep refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ The pipeline is: `echada cast` creates a `.vox` file -> `diga --import-vox voice
 
 ## App Group configuration (required)
 
-This package depends on [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) for shared model storage. SwiftAcervo v0.10.0 resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. There is **no silent fallback**.
+This package depends on [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) for shared model storage. SwiftAcervo resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. There is **no silent fallback**.
 
 - **Signed UI apps (macOS / iOS)**: declare `com.apple.security.application-groups` with `group.intrusive-memory.models` in your `.entitlements` file. iOS apps additionally need `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the launch environment.
 - **CLI tools, scripts, CI jobs, test runners**: export `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the shell or job environment. The standard place is `~/.zprofile`:
@@ -429,7 +429,6 @@ public actor VoxAltaModelManager {
     public func loadModel(repo: String) async throws -> any SpeechGenerationModel
     public func loadModel(_ modelRepo: Qwen3TTSModelRepo) async throws -> any SpeechGenerationModel
     public func unloadModel()
-    public func migrateIfNeeded()                          // Legacy -> Acervo migration
     public nonisolated func isModelInAcervo(_ modelId: String) -> Bool
     public func checkMemory(forModelSizeBytes: Int) -> Bool   // Warning only, non-blocking
     public func validateMemory(forModelSizeBytes: Int) throws // Hard gate
@@ -679,7 +678,7 @@ diga -v voice.vox "Hello, world!"      # Synthesize directly (no import needed)
 
 ### App Group / ACERVO_APP_GROUP_ID (REQUIRED for all integrators)
 
-The `~/Library/SharedModels/` path above is the App Group container `group.intrusive-memory.models`. SwiftAcervo v0.10.0 resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. **There is no silent fallback.** If neither source is configured, `Acervo.sharedModelsDirectory` calls `fatalError` and the process traps immediately.
+The `~/Library/SharedModels/` path above is the App Group container `group.intrusive-memory.models`. SwiftAcervo resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. **There is no silent fallback.** If neither source is configured, `Acervo.sharedModelsDirectory` calls `fatalError` and the process traps immediately.
 
 #### Signed UI apps (macOS / iOS)
 
@@ -762,6 +761,12 @@ On CI (`GITHUB_ACTIONS` set):
 ---
 
 ## Recent Changes
+
+### Unreleased
+
+- **chore**: Bump SwiftAcervo pin `0.14.0` -> `0.16.0`
+- **refactor**: Remove `VoxAltaModelManager.migrateIfNeeded()` and its call site; `Acervo.migrateFromLegacyPaths()` is no longer part of the SwiftAcervo 0.16.x public surface. App Group resolution handles fresh installs directly.
+- **docs**: Drop stale "SwiftAcervo v0.10.0" version string from README and AGENTS
 
 ### v0.10.1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.11.1
+**Current Version**: 0.11.1-dev
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.11.1-dev
+**Current Version**: 0.11.2
 
 ---
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,6 @@
 // swift-tools-version: 6.2
 
-import Foundation
 import PackageDescription
-
-// In CI we always pin to released remotes. Locally, prefer a sibling checkout
-// at ../<name> if present so in-flight changes can be exercised end-to-end
-// without publishing a release. Falls back to the remote pin if the sibling
-// directory is missing, so fresh clones still build.
-//
-// When this manifest is evaluated as a transitive dependency inside Xcode's
-// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
-// dependency lives as a sibling in the same directory. Treating those as
-// in-development local paths produces conflicting package identities, so we
-// must skip the sibling shortcut in that context.
-let manifestDir = (#filePath as NSString).deletingLastPathComponent
-let isSPMCheckout =
-  manifestDir.contains("/SourcePackages/checkouts/")
-  || manifestDir.contains("/.build/checkouts/")
-let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
-let useLocalSiblings = !isCI && !isSPMCheckout
-
-func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
-}
-
-/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
-/// remote branch when no local sibling exists. Use only when a temporary
-/// pre-release dependency on a feature branch is required; switch back to the
-/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
-func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, branch: branch)
-}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -57,10 +19,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    sibling(
-      "SwiftHablare",
-      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
-      from: "6.1.1"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.1")),
     // PINNED to 0.8.x line. mlx-audio-swift 0.8.3 itself pins
     // swift-tokenizers to `.upToNextMinor(from: "0.5.0")` (`>= 0.5.0, < 0.6.0`)
     // because swift-tokenizers 0.6.x is a breaking release that swaps the
@@ -75,21 +35,15 @@ let package = Package(
     // SPM resolution under Xcode 26). Do not relax this constraint without a
     // deliberate migration PR. See AGENTS.md → "Pending Breaking Upgrades".
     .package(
-      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMinor(from: "0.8.3")),
-    sibling(
-      "SwiftAcervo",
-      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-      from: "0.16.0"),
-    sibling(
-      "SwiftTuberia",
-      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
-      from: "0.7.2"),
+      url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMinor(from: "0.8.6")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.16.1")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.7.4")),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    sibling(
-      "vox-format",
-      remote: "https://github.com/intrusive-memory/vox-format.git",
-      from: "0.3.1"),
+    .package(
+      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ let package = Package(
     sibling(
       "SwiftAcervo",
       remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-      from: "0.14.0"),
+      from: "0.16.0"),
     sibling(
       "SwiftTuberia",
       remote: "https://github.com/intrusive-memory/SwiftTuberia.git",

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -19,8 +57,10 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.1")),
+    sibling(
+      "SwiftHablare",
+      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
+      from: "6.1.1"),
     // PINNED to 0.8.x line. mlx-audio-swift 0.8.3 itself pins
     // swift-tokenizers to `.upToNextMinor(from: "0.5.0")` (`>= 0.5.0, < 0.6.0`)
     // because swift-tokenizers 0.6.x is a breaking release that swaps the
@@ -36,14 +76,20 @@ let package = Package(
     // deliberate migration PR. See AGENTS.md → "Pending Breaking Upgrades".
     .package(
       url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMinor(from: "0.8.3")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.14.0")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.7.2")),
+    sibling(
+      "SwiftAcervo",
+      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+      from: "0.14.0"),
+    sibling(
+      "SwiftTuberia",
+      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
+      from: "0.7.2"),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.3.1")),
+    sibling(
+      "vox-format",
+      remote: "https://github.com/intrusive-memory/vox-format.git",
+      from: "0.3.1"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For detailed integration instructions, see **[Produciesta Integration Guide](doc
 
 ## App Group configuration (required)
 
-This package depends on [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) for shared model storage. SwiftAcervo v0.10.0 resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. There is **no silent fallback**.
+This package depends on [SwiftAcervo](https://github.com/intrusive-memory/SwiftAcervo) for shared model storage. SwiftAcervo resolves its App Group ID in this order: `ACERVO_APP_GROUP_ID` env var → `com.apple.security.application-groups` entitlement (macOS only) → `fatalError`. There is **no silent fallback**.
 
 - **Signed UI apps (macOS / iOS)**: declare `com.apple.security.application-groups` with `group.intrusive-memory.models` in your `.entitlements` file. iOS apps additionally need `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the launch environment.
 - **CLI tools, scripts, CI jobs, test runners**: export `ACERVO_APP_GROUP_ID=group.intrusive-memory.models` in the shell or job environment. The standard place is `~/.zprofile`:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew install diga
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.11.1")
+    .package(url: "https://github.com/intrusive-memory/SwiftVoxAlta.git", from: "0.11.2")
 ]
 ```
 

--- a/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaModelManager.swift
@@ -255,9 +255,6 @@ public actor VoxAltaModelManager {
     _currentModelRepo
   }
 
-  /// Whether legacy model migration has already been attempted this session.
-  private var migrationAttempted = false
-
   /// Initializes an empty model manager with no model loaded.
   ///
   /// Triggers Acervo component registration on first instantiation via
@@ -268,30 +265,6 @@ public actor VoxAltaModelManager {
   }
 
   // MARK: - Acervo Integration
-
-  /// Runs Acervo's one-time migration from any legacy cache layout to whatever
-  /// shared directory Acervo currently resolves to. The destination path is
-  /// owned by Acervo (`Acervo.sharedModelsDirectory`) — VoxAlta does not assume
-  /// or hardcode it.
-  public func migrateIfNeeded() {
-    guard !migrationAttempted else { return }
-    migrationAttempted = true
-    do {
-      let migrated = try Acervo.migrateFromLegacyPaths()
-      if !migrated.isEmpty {
-        let destination = Acervo.sharedModelsDirectory.path
-        FileHandle.standardError.write(
-          Data(
-            "Migrated \(migrated.count) model(s) to \(destination)\n".utf8
-          ))
-      }
-    } catch {
-      FileHandle.standardError.write(
-        Data(
-          "Warning: model migration failed: \(error.localizedDescription)\n".utf8
-        ))
-    }
-  }
 
   /// Checks whether a model is available in Acervo's shared directory.
   ///
@@ -451,9 +424,6 @@ public actor VoxAltaModelManager {
   /// the nonisolated Task boundary (the model itself is non-Sendable).
   private func _performLoad(repo: String) async throws -> LoadedModelBox {
     performLoadInvocationCount += 1
-
-    // One-time migration from legacy cache to Acervo shared directory
-    migrateIfNeeded()
 
     // Unload current model if switching repos
     if cachedModel != nil {

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -30,7 +30,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.11.1"
+  public static let version = "0.11.1-dev"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -30,7 +30,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.11.1-dev"
+  public static let version = "0.11.2"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.11.1"
+  static let current = "0.11.1-dev"
 }

--- a/Sources/diga/Version.swift
+++ b/Sources/diga/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.11.1-dev"
+  static let current = "0.11.2"
 }

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,143 @@
+# SwiftAcervo 0.16.x Migration
+
+**Status:** ✅ Applied 2026-05-24. Package pin bumped to 0.16.0, `migrateIfNeeded()` removed, version-string doc drift fixed. `make build` + `make test-unit` (198 tests) both pass on the development branch.
+
+Audit of SwiftVoxAlta against `/Users/stovak/Projects/SwiftAcervo/Docs/USAGE-library.md` (SwiftAcervo 0.16.1-dev).
+
+**Overall assessment.** Code is largely 0.16-compatible — bare `ComponentDescriptor` registrations, `AcervoManager.shared.withComponentAccess`, `Acervo.ensureComponentReady`, `Acervo.isModelAvailable`, and a discriminated `AcervoError` switch are all already in idiomatic 0.16.x style. The one true API removal is `Acervo.migrateFromLegacyPaths()`, which no longer exists in 0.16.x. Everything else is doc drift (still saying "v0.10.0") and a routine pin bump.
+
+---
+
+## 1. Package.swift / Package.resolved bumps
+
+### 1.1 Bump SwiftAcervo dependency ✅ 2026-05-24
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/Package.swift` (around line 83)
+- **Current:**
+  ```swift
+  sibling(
+    "SwiftAcervo",
+    remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+    from: "0.14.0"),
+  ```
+- **Required:**
+  ```swift
+  sibling(
+    "SwiftAcervo",
+    remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+    from: "0.16.0"),
+  ```
+- After bumping, run a clean resolve so `Package.resolved` (currently pinned to revision `15fd376…`, `version 0.14.0` at lines 130–138) advances to the 0.16.x tag.
+
+---
+
+## 2. Code changes
+
+### 2.1 `Acervo.migrateFromLegacyPaths()` no longer exists in 0.16.x ✅ 2026-05-24
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/Sources/SwiftVoxAlta/VoxAltaModelManager.swift`
+- **Lines:** 276–294 (`migrateIfNeeded()`), call site at line 456 (`_performLoad` → `migrateIfNeeded()`), and the gating `migrationAttempted` field at line 259.
+- **Current behavior:** On first model load, calls `Acervo.migrateFromLegacyPaths()` and prints a "Migrated N model(s) to …" line to stderr.
+- **Problem:** `migrateFromLegacyPaths` is not part of the 0.16.x public surface (not in `USAGE-library.md`, not in `Sources/SwiftAcervo/`). The build will fail.
+- **Required change:** Delete `migrateIfNeeded()` entirely (the legacy `intrusive-memory/Models/{LLM,TTS,Audio,VLM}/` cache migration is an SwiftAcervo concern that 0.16.x dropped along with the legacy paths themselves). Remove the call at line 456 inside `_performLoad`, and the `migrationAttempted` field at line 259. Also strip the doc-comment fragments referencing "legacy cache migration" at lines 270–275, 455, and the `init` doc at line 263.
+- Replacement: nothing. The App Group resolution already handles fresh installs correctly; there is no in-place legacy path to migrate from on 0.16.x consumers that have only ever used the App Group container.
+- If the team needs to preserve a one-time migration story for users coming from a pre-App-Group SwiftAcervo cache, do it in a separate follow-up PR — do not block the 0.16 bump on it.
+
+### 2.2 (Verify only — no change required) Bare `ComponentDescriptor` registrations
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/Sources/SwiftVoxAlta/VoxAltaModelManager.swift`
+- **Lines:** 127–181 (the `qwen3TTSComponentDescriptors` array — 7 descriptors).
+- **Status:** Already uses the bare un-hydrated initializer `init(id:type:displayName:repoId:minimumMemoryBytes:metadata:)`. No `files:` arrays, no pre-baked `estimatedSizeBytes`. This is exactly the 0.16.x recommended pattern. Leave as-is.
+
+### 2.3 (Verify only — no change required) `withComponentAccess` + `ensureComponentReady` flow
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/Sources/SwiftVoxAlta/VoxAltaModelManager.swift`
+- **Lines:** 319–379 (`_loadModelWithComponentValidation`), 479 (`Acervo.ensureComponentReady(componentId)`).
+- **Status:** Already uses `AcervoManager.shared.withComponentAccess(componentId) { @Sendable _ in ... }` and `Acervo.ensureComponentReady`. The `AcervoError` switch at 333–373 already discriminates `modelNotFound`, `integrityCheckFailed`, `downloadSizeMismatch`, `componentNotRegistered`, `componentNotHydrated`, `offlineModeActive`, `fileNotInManifest`, `manifestIntegrityFailed`, `manifestDownloadFailed`, with a `default` catch-all. All listed cases still exist in the 0.16.x `AcervoError` enum. Leave as-is.
+- **Optional polish (low priority):** the `default:` branch could additionally match the new 0.16.x cases `manifestFetchFailed(slug:status:)`, `manifestModelIdMismatch(expected:actual:)`, `urlRequiredForSlug(_:)`, `componentFileNotFound(component:file:)`, `componentNotDownloaded(_:)`, `localPathNotFound(url:)`, etc. — but since none of those are reachable through the call sites VoxAlta actually invokes (`ensureComponentReady`, `withComponentAccess`), the default fall-through is acceptable.
+
+### 2.4 (Verify only — no change required) `isModelAvailable` gating
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/Sources/SwiftVoxAlta/VoxAltaModelManager.swift:300–302`
+- **Status:** The synchronous probe `Acervo.isModelAvailable(modelId)` is used from a `nonisolated` helper exposed as `isModelInAcervo`. This is the correct fast-path API in 0.16.x (the doc explicitly says: "Prefer `availability(_:)` for UI; use this in fast-path guards inside `ensureAvailable` flows"). Since VoxAlta is a library — not a UI consumer — the synchronous form is fine.
+- **Optional polish (low priority):** if a downstream UI consumer (Produciesta) wants three-state progress, expose an additional async helper `availability(_:) async -> ModelAvailability` forwarding to `AcervoManager.shared.availability(_:)`. Not required for the 0.16 bump.
+
+### 2.5 (Verify only — no change required) `Acervo.slugify` + `Acervo.component`
+
+- **Files:** `VoxAltaModelManager.swift:116` (`Acervo.slugify(rawValue)`), `VoxAltaModelManager.swift:474` (`Acervo.component(componentId)`), `DigaBinaryIntegrationTests.swift:139` (`Acervo.sharedModelsDirectory.path`).
+- **Status:** All three APIs exist verbatim in 0.16.x. Leave as-is.
+
+---
+
+## 3. Documentation updates
+
+All four foundational docs still say "SwiftAcervo v0.10.0" even though the pin is v0.14 and we are bumping to v0.16. None of the behavioural claims have changed (resolution order, no-silent-fallback, fatalError trap), only the version string.
+
+### 3.1 README — version string drift ✅ 2026-05-24
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/README.md:133`
+- **Current:** `… SwiftAcervo v0.10.0 resolves its App Group ID in this order…`
+- **Required:** drop the version pin from the sentence (it ages out of date every cycle). Replace with: `… SwiftAcervo resolves its App Group ID in this order…`
+
+### 3.2 AGENTS — two version-string occurrences ✅ 2026-05-24
+
+- **File:** `/Users/stovak/Projects/SwiftVoxAlta/AGENTS.md`
+- **Line 48:** same fix as README (drop "v0.10.0").
+- **Line 682:** same fix.
+- Also add a Changelog entry under the existing `## Changelog` block (around lines 757+) noting the 0.14 → 0.16 bump and the removal of the `migrateFromLegacyPaths` call site.
+
+### 3.3 CLAUDE.md and GEMINI.md
+
+- **Files:** `/Users/stovak/Projects/SwiftVoxAlta/CLAUDE.md:64` and `/Users/stovak/Projects/SwiftVoxAlta/GEMINI.md:44`.
+- Both already point at AGENTS.md's "App Group configuration (required)" section by reference. No version string to fix. Leave as-is.
+
+### 3.4 (Optional) USAGE-library.md cross-link
+
+- In AGENTS.md's App Group section (around line 680), link to `Docs/USAGE-library.md` in the SwiftAcervo repo so readers can confirm the resolution order in the canonical source rather than the copy embedded in AGENTS.md.
+
+---
+
+## 4. CI / Makefile / entitlements
+
+### 4.1 (No change required) GitHub Actions workflows
+
+- `/Users/stovak/Projects/SwiftVoxAlta/.github/workflows/tests.yml:8`
+- `/Users/stovak/Projects/SwiftVoxAlta/.github/workflows/release.yml:19`
+- `/Users/stovak/Projects/SwiftVoxAlta/.github/workflows/ensure-model-cdn.yml:20`
+- All three already export `ACERVO_APP_GROUP_ID: group.intrusive-memory.models` at job level. The historical v0.10 audit finding ("no `ACERVO_APP_GROUP_ID` exports in CI workflows") is no longer accurate. Leave as-is.
+
+### 4.2 (No change required) Makefile
+
+- `/Users/stovak/Projects/SwiftVoxAlta/Makefile:123–128` already defers to `Acervo.sharedModelsDirectory` for the model cache destination instead of hardcoding a path. Leave as-is.
+
+### 4.3 (No change required) Entitlements
+
+- SwiftVoxAlta is a library + the unsigned `diga` CLI; neither owns an `.entitlements` file. The App Group entitlement is delivered by downstream UI apps (Produciesta) and is already documented in AGENTS.md §680. Leave as-is.
+
+---
+
+## 5. Tests
+
+### 5.1 (No change required) `AcervoEnvironmentTrait`
+
+- `/Users/stovak/Projects/SwiftVoxAlta/Tests/SwiftVoxAltaTests/AcervoEnvironmentTrait.swift`
+- `/Users/stovak/Projects/SwiftVoxAlta/Tests/DigaTests/AcervoEnvironmentTrait.swift`
+- Both correctly `setenv("ACERVO_APP_GROUP_ID", "group.intrusive-memory.models", 0)` before any Acervo path resolution. Pattern still matches the 0.16.x resolution order. Leave as-is.
+
+### 5.2 (No change required) `ComponentDescriptorRegistrationTests`
+
+- `/Users/stovak/Projects/SwiftVoxAlta/Tests/SwiftVoxAltaTests/ComponentDescriptorRegistrationTests.swift`
+- Asserts `descriptor.needsHydration == true` and `descriptor.files.isEmpty` after registration — exactly the 0.16.x bare-descriptor invariant. Leave as-is.
+
+### 5.3 Strip `migrateIfNeeded`-related test side-effects (only if §2.1 changes any test fixture)
+
+- If §2.1's deletion of `migrateIfNeeded()` removes a public symbol or stderr line that a test asserts on, drop those expectations. A grep of `Tests/` shows no test currently calls `migrateIfNeeded` or asserts on the "Migrated N model(s)" stderr line, so this is almost certainly a no-op — verify after applying §2.1.
+
+---
+
+## Summary
+
+- **One real code change:** delete `migrateIfNeeded()` and its call site (§2.1).
+- **One pin bump:** Package.swift `0.14.0` → `0.16.0` (§1.1).
+- **Three doc edits:** strip stale "v0.10.0" version strings in README and AGENTS (§3.1, §3.2).
+- Everything else flagged in the historical v0.10 audit (component registrations, error mapping, CI env var, Makefile path hardcoding, App Group docs) is already compliant with 0.16.x. No further work required.


### PR DESCRIPTION
# Release v0.11.2

## Summary

Routine maintenance release that completes the SwiftAcervo 0.14 → 0.16 migration (dropping the removed `migrate` API), refreshes intrusive-memory/* dependencies to their latest published releases, and bumps the mlx-audio-swift floor within the pinned 0.8.x line.

### New Features
- None — maintenance release.

### Bug Fixes
- None — no behavioral changes.

### Dependencies
- SwiftAcervo: 0.14.x → 0.16.1 (removed deprecated `migrate` API call sites; see [TODO items resolved](AGENTS.md))
- SwiftTuberia: 0.7.2 → 0.7.4
- mlx-audio-swift floor: 0.8.3 → 0.8.6 (still pinned to `.upToNextMinor(from: 0.8.x)` per the swift-tokenizers 0.6.x compatibility note in `Package.swift`)
- SwiftHablare, vox-format: unchanged at 6.1.1 and 0.3.1

### Testing
- Unit Tests CI gate: passing.

### Documentation
- `AGENTS.md` Current Version → 0.11.2
- `README.md` SPM install snippet → `from: "0.11.2"`
- SwiftAcervo 0.16.x migration TODO items marked complete