### PR TITLE
Release v0.14.0: TTSLanguage enum and model-aligned language threading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.13.1-dev
+**Current Version**: 0.14.0
 
 ---
 
@@ -778,6 +778,13 @@ On CI (`GITHUB_ACTIONS` set):
 ---
 
 ## Recent Changes
+
+### v0.14.0
+
+- **feat**: New `TTSLanguage` enum (`Sources/SwiftVoxAlta/TTSLanguage.swift`) whose cases mirror the model's on-device `codec_language_id` keys exactly. Resolves from BCP-47 tags, `Locale`, and loose aliases, and exposes `modelName` (the key the model conditions on) plus `logConsumption(stage:detail:)` tracing.
+- **feat**: Thread a model-aligned language through the synthesis pipeline. `VoiceLockManager.createLock` and both `generateAudio` overloads now take `language: TTSLanguage` instead of a stringly-typed `language: String`, forwarding `language.modelName` to the speaker encoder so the tokenizer conditions on a key the model actually recognizes (fixes silent fall-through to un-conditioned generation).
+- **fix**: `DigaEngine` synthesis paths pass `.english` / `TTSLanguage.english.modelName` explicitly rather than the bare `"en"` literal.
+- **breaking**: `VoiceLockManager.generateAudio(...)` no longer defaults `language`; callers must pass an explicit `TTSLanguage`. `createLock`'s `language:` parameter changed type from `String` to `TTSLanguage` (defaults to `.english`).
 
 ### v0.13.1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Documentation for AI agents working with the SwiftVoxAlta codebase.
 
-**Current Version**: 0.13.1
+**Current Version**: 0.13.1-dev
 
 ---
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,44 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
+
+// In CI we always pin to released remotes. Locally, prefer a sibling checkout
+// at ../<name> if present so in-flight changes can be exercised end-to-end
+// without publishing a release. Falls back to the remote pin if the sibling
+// directory is missing, so fresh clones still build.
+//
+// When this manifest is evaluated as a transitive dependency inside Xcode's
+// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
+// dependency lives as a sibling in the same directory. Treating those as
+// in-development local paths produces conflicting package identities, so we
+// must skip the sibling shortcut in that context.
+let manifestDir = (#filePath as NSString).deletingLastPathComponent
+let isSPMCheckout =
+  manifestDir.contains("/SourcePackages/checkouts/")
+  || manifestDir.contains("/.build/checkouts/")
+let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
+let useLocalSiblings = !isCI && !isSPMCheckout
+
+func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, .upToNextMajor(from: version))
+}
+
+/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
+/// remote branch when no local sibling exists. Use only when a temporary
+/// pre-release dependency on a feature branch is required; switch back to the
+/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
+func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
+  let localPath = "../\(name)"
+  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
+    return .package(path: localPath)
+  }
+  return .package(url: remote, branch: branch)
+}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -23,8 +61,10 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.1")),
+    sibling(
+      "SwiftHablare",
+      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
+      from: "6.1.1"),
     // PINNED to 0.8.x line. mlx-audio-swift 0.8.3 itself pins
     // swift-tokenizers to `.upToNextMinor(from: "0.5.0")` (`>= 0.5.0, < 0.6.0`)
     // because swift-tokenizers 0.6.x is a breaking release that swaps the
@@ -40,14 +80,20 @@ let package = Package(
     // deliberate migration PR. See AGENTS.md → "Pending Breaking Upgrades".
     .package(
       url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMinor(from: "0.8.6")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.19.2")),
-    .package(
-      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.7.4")),
+    sibling(
+      "SwiftAcervo",
+      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
+      from: "0.19.2"),
+    sibling(
+      "SwiftTuberia",
+      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
+      from: "0.7.4"),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    .package(
-      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.4.0")),
+    sibling(
+      "vox-format",
+      remote: "https://github.com/intrusive-memory/vox-format.git",
+      from: "0.4.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,44 +1,6 @@
 // swift-tools-version: 6.2
 
-import Foundation
 import PackageDescription
-
-// In CI we always pin to released remotes. Locally, prefer a sibling checkout
-// at ../<name> if present so in-flight changes can be exercised end-to-end
-// without publishing a release. Falls back to the remote pin if the sibling
-// directory is missing, so fresh clones still build.
-//
-// When this manifest is evaluated as a transitive dependency inside Xcode's
-// `SourcePackages/checkouts/` or SwiftPM's `.build/checkouts/`, every other
-// dependency lives as a sibling in the same directory. Treating those as
-// in-development local paths produces conflicting package identities, so we
-// must skip the sibling shortcut in that context.
-let manifestDir = (#filePath as NSString).deletingLastPathComponent
-let isSPMCheckout =
-  manifestDir.contains("/SourcePackages/checkouts/")
-  || manifestDir.contains("/.build/checkouts/")
-let isCI = ProcessInfo.processInfo.environment["CI"] == "true"
-let useLocalSiblings = !isCI && !isSPMCheckout
-
-func sibling(_ name: String, remote: String, from version: Version) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, .upToNextMajor(from: version))
-}
-
-/// Same sibling-priority pattern as ``sibling(_:remote:from:)`` but pins to a
-/// remote branch when no local sibling exists. Use only when a temporary
-/// pre-release dependency on a feature branch is required; switch back to the
-/// version-pinned ``sibling(_:remote:from:)`` once the upstream tags a release.
-func sibling(_ name: String, remote: String, branch: String) -> Package.Dependency {
-  let localPath = "../\(name)"
-  if useLocalSiblings && FileManager.default.fileExists(atPath: localPath) {
-    return .package(path: localPath)
-  }
-  return .package(url: remote, branch: branch)
-}
 
 let package = Package(
   name: "SwiftVoxAlta",
@@ -61,10 +23,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    sibling(
-      "SwiftHablare",
-      remote: "https://github.com/intrusive-memory/SwiftHablare.git",
-      from: "6.1.1"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftHablare.git", .upToNextMajor(from: "6.1.1")),
     // PINNED to 0.8.x line. mlx-audio-swift 0.8.3 itself pins
     // swift-tokenizers to `.upToNextMinor(from: "0.5.0")` (`>= 0.5.0, < 0.6.0`)
     // because swift-tokenizers 0.6.x is a breaking release that swaps the
@@ -80,20 +40,14 @@ let package = Package(
     // deliberate migration PR. See AGENTS.md → "Pending Breaking Upgrades".
     .package(
       url: "https://github.com/intrusive-memory/mlx-audio-swift.git", .upToNextMinor(from: "0.8.6")),
-    sibling(
-      "SwiftAcervo",
-      remote: "https://github.com/intrusive-memory/SwiftAcervo.git",
-      from: "0.19.2"),
-    sibling(
-      "SwiftTuberia",
-      remote: "https://github.com/intrusive-memory/SwiftTuberia.git",
-      from: "0.7.4"),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftAcervo.git", .upToNextMajor(from: "0.19.2")),
+    .package(
+      url: "https://github.com/intrusive-memory/SwiftTuberia.git", .upToNextMajor(from: "0.7.4")),
     .package(
       url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.7.1")),
-    sibling(
-      "vox-format",
-      remote: "https://github.com/intrusive-memory/vox-format.git",
-      from: "0.4.0"),
+    .package(
+      url: "https://github.com/intrusive-memory/vox-format.git", .upToNextMajor(from: "0.4.0")),
   ],
   targets: [
     .target(

--- a/Sources/DigaCLICore/DigaEngine.swift
+++ b/Sources/DigaCLICore/DigaEngine.swift
@@ -367,7 +367,7 @@ actor DigaEngine {
         wavData = try await VoiceLockManager.generateAudio(
           context: context,
           voiceLock: voiceLock,
-          language: "en",
+          language: .english,
           modelManager: voxAltaModelManager,
           modelRepo: resolvedBaseModelRepo,
           cache: voiceCache,
@@ -466,7 +466,7 @@ actor DigaEngine {
       let wavData = try await VoiceLockManager.generateAudio(
         context: context,
         voiceLock: voiceLock,
-        language: "en",
+        language: .english,
         modelManager: voxAltaModelManager,
         modelRepo: resolvedBaseModelRepo,
         cache: voiceCache,
@@ -537,7 +537,7 @@ actor DigaEngine {
           voice: speakerName,
           refAudio: nil,
           refText: nil,
-          language: "en",
+          language: TTSLanguage.english.modelName,
           instruct: instruct,
           generationParameters: GenerateParameters()
         )

--- a/Sources/DigaCLICore/Version.swift
+++ b/Sources/DigaCLICore/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.13.1-dev"
+  static let current = "0.14.0"
 }

--- a/Sources/DigaCLICore/Version.swift
+++ b/Sources/DigaCLICore/Version.swift
@@ -1,4 +1,4 @@
 /// Version information for the diga CLI.
 enum DigaVersion {
-  static let current = "0.13.1"
+  static let current = "0.13.1-dev"
 }

--- a/Sources/SwiftVoxAlta/TTSLanguage.swift
+++ b/Sources/SwiftVoxAlta/TTSLanguage.swift
@@ -61,8 +61,10 @@ public enum TTSLanguage: String, Sendable, CaseIterable, Equatable {
     "english": .english, "chinese": .chinese, "german": .german,
     "italian": .italian, "portuguese": .portuguese, "spanish": .spanish,
     "japanese": .japanese, "korean": .korean, "french": .french, "russian": .russian,
-    "beijing_dialect": .beijingDialect, "beijingdialect": .beijingDialect, "beijing": .beijingDialect,
-    "sichuan_dialect": .sichuanDialect, "sichuandialect": .sichuanDialect, "sichuan": .sichuanDialect,
+    "beijing_dialect": .beijingDialect, "beijingdialect": .beijingDialect,
+    "beijing": .beijingDialect,
+    "sichuan_dialect": .sichuanDialect, "sichuandialect": .sichuanDialect,
+    "sichuan": .sichuanDialect,
   ]
 
   /// Resolve from a Swift `Locale`.

--- a/Sources/SwiftVoxAlta/TTSLanguage.swift
+++ b/Sources/SwiftVoxAlta/TTSLanguage.swift
@@ -1,0 +1,132 @@
+//
+//  TTSLanguage.swift
+//  SwiftVoxAlta
+//
+//  Typed, model-aligned language identity for the generation pipeline.
+//
+
+import Foundation
+
+/// The set of languages Qwen3-TTS can actually condition on.
+///
+/// These cases mirror the model's on-device `codec_language_id` keys exactly —
+/// there is intentionally **no** regional sub-variant (no `en-US`/`en-GB`),
+/// because the model has a single representation per language. Region/script
+/// information carried by a `Locale` is therefore *lossy* at this boundary:
+/// `en_GB` and `en_US` both resolve to ``english``. Callers that need a regional
+/// accent must control the clone reference audio in the `.vox`, not the language.
+///
+/// This is the type that threads through every internal generation layer
+/// (``VoxAltaVoiceProvider`` → ``VoiceLockManager`` → the model boundary),
+/// replacing the previous bare `String` (defaulting to `"en"`) which never
+/// resolved to a model language token and produced un-conditioned output.
+public enum TTSLanguage: String, Sendable, CaseIterable, Equatable {
+  case chinese
+  case english
+  case german
+  case italian
+  case portuguese
+  case spanish
+  case japanese
+  case korean
+  case french
+  case russian
+  case beijingDialect
+  case sichuanDialect
+  /// Let the model infer the language. Emits no language token (matches the
+  /// historical `"en"` behavior). Only reachable when explicitly requested.
+  case auto
+
+  /// The exact key the model's `codec_language_id` map expects.
+  public var modelName: String {
+    switch self {
+    case .beijingDialect: return "beijing_dialect"
+    case .sichuanDialect: return "sichuan_dialect"
+    default: return rawValue
+    }
+  }
+
+  // MARK: - Resolution
+
+  /// ISO 639-1 codes the model supports. Dialects and `auto` are explicit-only
+  /// (not reachable from a plain locale).
+  private static let iso639: [String: TTSLanguage] = [
+    "zh": .chinese, "en": .english, "de": .german, "it": .italian,
+    "pt": .portuguese, "es": .spanish, "ja": .japanese, "ko": .korean,
+    "fr": .french, "ru": .russian,
+  ]
+
+  /// Full language names, model-name forms, and short dialect aliases.
+  private static let aliases: [String: TTSLanguage] = [
+    "english": .english, "chinese": .chinese, "german": .german,
+    "italian": .italian, "portuguese": .portuguese, "spanish": .spanish,
+    "japanese": .japanese, "korean": .korean, "french": .french, "russian": .russian,
+    "beijing_dialect": .beijingDialect, "beijingdialect": .beijingDialect, "beijing": .beijingDialect,
+    "sichuan_dialect": .sichuanDialect, "sichuandialect": .sichuanDialect, "sichuan": .sichuanDialect,
+  ]
+
+  /// Resolve from a Swift `Locale`.
+  ///
+  /// Extracts the language code and maps it to a supported case. Any region the
+  /// locale carries (e.g. `GB` in `en_GB`) is dropped and logged in debug builds,
+  /// because the model cannot represent it.
+  ///
+  /// - Throws: ``VoxAltaError/unsupportedLanguage(_:)`` if the locale's language
+  ///   is not one the model supports.
+  public init(locale: Locale) throws {
+    guard let code = locale.language.languageCode?.identifier.lowercased(),
+      let resolved = Self.iso639[code]
+    else {
+      throw VoxAltaError.unsupportedLanguage(locale.identifier)
+    }
+    if let region = locale.region?.identifier {
+      TTSLanguage.trace(
+        "resolve",
+        "\(locale.identifier) → \(resolved.modelName) (dropped region \(region); "
+          + "model has no regional variant)")
+    }
+    self = resolved
+  }
+
+  /// Resolve from an arbitrary tag: a BCP-47 locale identifier (`"en"`, `"en-GB"`,
+  /// `"es-MX"`), a full language name (`"english"`), a model-name form
+  /// (`"beijing_dialect"`), or the literal `"auto"`.
+  ///
+  /// This is the single normalization point at the SwiftHablare-facing boundary,
+  /// where the protocol hands us a `String languageCode`.
+  ///
+  /// - Throws: ``VoxAltaError/unsupportedLanguage(_:)`` if the tag cannot be
+  ///   mapped to a supported language.
+  public init(languageCode raw: String) throws {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    let lowered = trimmed.lowercased()
+    if lowered == "auto" {
+      self = .auto
+      return
+    }
+    if let direct = Self.aliases[lowered] {
+      self = direct
+      return
+    }
+    try self.init(locale: Locale(identifier: trimmed))
+  }
+
+  // MARK: - Debug Tracing
+
+  /// Emit a `[lang]` trace line to stderr in debug builds only.
+  ///
+  /// Used at each consumption site so the resolved language can be followed as it
+  /// crosses the stack (provider → voice-lock → model boundary). Compiled out of
+  /// release builds.
+  public static func trace(_ stage: String, _ message: String) {
+    #if DEBUG
+      FileHandle.standardError.write(Data("[lang] \(stage): \(message)\n".utf8))
+    #endif
+  }
+
+  /// Convenience: log this language being consumed at `stage` with optional context.
+  public func logConsumption(stage: String, detail: String = "") {
+    let extra = detail.isEmpty ? "" : " — \(detail)"
+    TTSLanguage.trace(stage, "\(modelName)\(extra)")
+  }
+}

--- a/Sources/SwiftVoxAlta/VoiceLockManager.swift
+++ b/Sources/SwiftVoxAlta/VoiceLockManager.swift
@@ -51,11 +51,11 @@ public enum VoiceLockManager: Sendable {
   ///   - sampleSentence: The text that was spoken in the candidate audio. If nil,
   ///     falls back to the default reference text.
   ///   - modelRepo: The Base model variant to use for cloning. Defaults to `.base1_7B`.
-  ///   - language: BCP 47 language tag (e.g. `"en"`, `"es"`, `"fr-FR"`) of the reference
-  ///     audio / `sampleSentence`. Forwarded to the speaker encoder so the tokenizer aligns
-  ///     the reference text against the reference audio. Defaults to `"en"` (the previous
-  ///     hardcoded value) for backward compatibility. The caller (echada) is responsible for
-  ///     supplying a `sampleSentence` in the same language; `createLock` does not translate.
+  ///   - language: The ``TTSLanguage`` of the reference audio / `sampleSentence`. Forwarded
+  ///     to the speaker encoder (as `language.modelName`) so the tokenizer aligns the
+  ///     reference text against the reference audio. Defaults to `.english`. The caller
+  ///     (echada) is responsible for supplying a `sampleSentence` in the same language;
+  ///     `createLock` does not translate.
   /// - Returns: A `VoiceLock` containing the serialized clone prompt.
   /// - Throws: `VoxAltaError.cloningFailed` if clone prompt extraction fails,
   ///           `VoxAltaError.modelNotAvailable` if the Base model cannot be loaded.
@@ -66,7 +66,7 @@ public enum VoiceLockManager: Sendable {
     modelManager: VoxAltaModelManager,
     sampleSentence: String? = nil,
     modelRepo: Qwen3TTSModelRepo = .base1_7B,
-    language: String = "en"
+    language: TTSLanguage = .english
   ) async throws -> VoiceLock {
     // Load Base model (supports voice cloning)
     let model = try await modelManager.loadModel(modelRepo)
@@ -89,12 +89,13 @@ public enum VoiceLockManager: Sendable {
     }
 
     // Create voice clone prompt
+    language.logConsumption(stage: "voicelock.createLock", detail: characterName)
     let clonePrompt: VoiceClonePrompt
     do {
       clonePrompt = try qwenModel.createVoiceClonePrompt(
         refAudio: refAudio,
         refText: sampleSentence ?? defaultReferenceSampleText,
-        language: language
+        language: language.modelName
       )
     } catch {
       throw VoxAltaError.cloningFailed(
@@ -136,7 +137,7 @@ public enum VoiceLockManager: Sendable {
   /// - Parameters:
   ///   - context: The generation context containing the phrase and optional metadata.
   ///   - voiceLock: The voice lock containing the serialized clone prompt.
-  ///   - language: The language code for generation. Defaults to "en".
+  ///   - language: The ``TTSLanguage`` for generation. Required — there is no default.
   ///   - modelManager: The model manager used to load the Base model.
   ///   - modelRepo: The Base model variant to use for generation. Defaults to `.base1_7B`.
   ///   - cache: Optional voice cache for clone prompt caching.
@@ -147,7 +148,7 @@ public enum VoiceLockManager: Sendable {
   public static func generateAudio(
     context: GenerationContext,
     voiceLock: VoiceLock,
-    language: String = "en",
+    language: TTSLanguage,
     modelManager: VoxAltaModelManager,
     modelRepo: Qwen3TTSModelRepo = .base1_7B,
     cache: VoxAltaVoiceCache? = nil,
@@ -186,7 +187,7 @@ public enum VoiceLockManager: Sendable {
   /// - Parameters:
   ///   - text: The text to synthesize.
   ///   - voiceLock: The voice lock containing the serialized clone prompt.
-  ///   - language: The language code for generation. Defaults to "en".
+  ///   - language: The ``TTSLanguage`` for generation. Required — there is no default.
   ///   - instruct: Optional performance direction for the TTS model (e.g., "Speak softly").
   ///     Forwarded to Qwen3-TTS as the `instruct` parameter to influence vocal delivery.
   ///   - modelManager: The model manager used to load the Base model.
@@ -200,7 +201,7 @@ public enum VoiceLockManager: Sendable {
   public static func generateAudio(
     text: String,
     voiceLock: VoiceLock,
-    language: String = "en",
+    language: TTSLanguage,
     instruct: String? = nil,
     modelManager: VoxAltaModelManager,
     modelRepo: Qwen3TTSModelRepo = .base1_7B,
@@ -256,6 +257,7 @@ public enum VoiceLockManager: Sendable {
     if let instruct = instruct {
       VoiceLockManagerLogger.log("📝 Instruct: \"\(instruct)\"")
     }
+    language.logConsumption(stage: "voicelock.generate", detail: voiceLock.characterName)
     VoiceLockManagerLogger.log(
       "🗣️  Text (\(text.count) chars): \"\(text.prefix(100))\(text.count > 100 ? "..." : "")\"")
 
@@ -289,10 +291,11 @@ public enum VoiceLockManager: Sendable {
             "  ↳ Chunk \(i + 1)/\(chunks.count) (\(chunk.count) chars): \"\(preview)\(suffix)\""
           )
 
+          TTSLanguage.trace("voicelock.→fork", "\(language.modelName) (chunk)")
           let rawChunkArray = try qwenModel.generateWithClonePrompt(
             text: chunk,
             clonePrompt: clonePrompt,
-            language: language,
+            language: language.modelName,
             instruct: instruct,
             temperature: settings.temperature,
             topP: settings.topP,
@@ -314,10 +317,11 @@ public enum VoiceLockManager: Sendable {
 
         audioArray = MLX.concatenated(arrays, axis: 0)
       } else {
+        TTSLanguage.trace("voicelock.→fork", language.modelName)
         audioArray = try qwenModel.generateWithClonePrompt(
           text: text,
           clonePrompt: clonePrompt,
-          language: language,
+          language: language.modelName,
           instruct: instruct,
           temperature: settings.temperature,
           topP: settings.topP,

--- a/Sources/SwiftVoxAlta/VoxAltaError.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaError.swift
@@ -30,6 +30,9 @@ public enum VoxAltaError: Error, LocalizedError, Sendable {
   /// Importing a voice from .vox format failed.
   case voxImportFailed(String)
 
+  /// The requested language tag could not be mapped to a model-supported language.
+  case unsupportedLanguage(String)
+
   public var errorDescription: String? {
     switch self {
     case .cloningFailed(let detail):
@@ -47,6 +50,9 @@ public enum VoxAltaError: Error, LocalizedError, Sendable {
       return "VOX export failed: \(detail)"
     case .voxImportFailed(let detail):
       return "VOX import failed: \(detail)"
+    case .unsupportedLanguage(let tag):
+      return
+        "Unsupported language '\(tag)'. Qwen3-TTS supports: chinese, english, german, italian, portuguese, spanish, japanese, korean, french, russian (plus beijing_dialect, sichuan_dialect). Regional accents are not selectable by language; control accent via the clone reference audio."
     }
   }
 }

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -30,7 +30,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.14.0-dev"
+  public static let version = "0.14.0"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -30,7 +30,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.13.1-dev"
+  public static let version = "0.14.0-dev"
 
   // MARK: - VoiceProvider Metadata
 
@@ -200,12 +200,18 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   public func generateAudio(context: GenerationContext, voiceId: String, languageCode: String)
     async throws -> Data
   {
+    // Normalize the SwiftHablare-supplied String to a model-aligned TTSLanguage
+    // exactly once, here at the provider boundary. Throws on unsupported tags
+    // instead of silently free-running on an un-conditioned default.
+    let language = try TTSLanguage(languageCode: languageCode)
+    language.logConsumption(stage: "provider", detail: "voiceId=\(voiceId)")
+
     // Route 1: CustomVoice preset speaker (fast path)
     if let speaker = presetSpeaker(for: voiceId) {
       return try await generateWithPresetSpeaker(
         text: context.phrase,
         speakerName: speaker.mlxSpeaker,
-        language: languageCode,
+        language: language,
         instruct: context.instruct
       )
     }
@@ -232,7 +238,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
     return try await VoiceLockManager.generateAudio(
       context: context,
       voiceLock: voiceLock,
-      language: languageCode,
+      language: language,
       modelManager: modelManager,
       modelRepo: baseModelRepo,
       cache: voiceCache,
@@ -388,13 +394,13 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   /// - Parameters:
   ///   - text: The text to synthesize.
   ///   - speakerName: The preset speaker ID (e.g., "ryan").
-  ///   - language: The language code for generation.
+  ///   - language: The ``TTSLanguage`` for generation.
   ///   - instruct: Optional performance direction for the TTS model.
   /// - Returns: WAV format audio data (24kHz, 16-bit PCM, mono).
   private func generateWithPresetSpeaker(
     text: String,
     speakerName: String,
-    language: String,
+    language: TTSLanguage,
     instruct: String? = nil
   ) async throws -> Data {
     let model = try await modelManager.loadModel(customVoiceModelRepo)
@@ -426,12 +432,13 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
       arrays.reserveCapacity(chunks.count * 2)
 
       for (i, chunk) in chunks.enumerated() {
+        TTSLanguage.trace("provider.preset.→fork", "\(language.modelName) (chunk)")
         let raw = try await qwenModel.generate(
           text: chunk,
           voice: speakerName,
           refAudio: nil,
           refText: nil,
-          language: language,
+          language: language.modelName,
           instruct: instruct,
           generationParameters: GenerateParameters()
         )
@@ -445,12 +452,13 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
 
       audioArray = MLX.concatenated(arrays, axis: 0)
     } else {
+      TTSLanguage.trace("provider.preset.→fork", language.modelName)
       audioArray = try await qwenModel.generate(
         text: text,
         voice: speakerName,
         refAudio: nil,
         refText: nil,
-        language: language,
+        language: language.modelName,
         instruct: instruct,
         generationParameters: GenerateParameters()
       )

--- a/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
+++ b/Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift
@@ -30,7 +30,7 @@ public final class VoxAltaVoiceProvider: VoiceProvider, @unchecked Sendable {
   // MARK: - Version
 
   /// Current version of the SwiftVoxAlta library
-  public static let version = "0.13.1"
+  public static let version = "0.13.1-dev"
 
   // MARK: - VoiceProvider Metadata
 

--- a/Tests/SwiftVoxAltaTests/TTSLanguageTests.swift
+++ b/Tests/SwiftVoxAltaTests/TTSLanguageTests.swift
@@ -1,0 +1,81 @@
+//
+//  TTSLanguageTests.swift
+//  SwiftVoxAltaTests
+//
+//  Verifies language-tag resolution into the model-aligned TTSLanguage enum,
+//  including the lossy region drop and the throwing behavior on unsupported tags.
+//
+
+import Foundation
+import Testing
+
+@testable import SwiftVoxAlta
+
+@Suite("TTSLanguage Resolution")
+struct TTSLanguageTests {
+
+  @Test("ISO 639-1 codes resolve to the matching case")
+  func iso639Resolves() throws {
+    #expect(try TTSLanguage(languageCode: "en") == .english)
+    #expect(try TTSLanguage(languageCode: "zh") == .chinese)
+    #expect(try TTSLanguage(languageCode: "es") == .spanish)
+    #expect(try TTSLanguage(languageCode: "ja") == .japanese)
+  }
+
+  @Test("Resolution is case-insensitive and trims whitespace")
+  func caseAndWhitespace() throws {
+    #expect(try TTSLanguage(languageCode: "EN") == .english)
+    #expect(try TTSLanguage(languageCode: "  fr  ") == .french)
+  }
+
+  @Test("Regional English tags collapse to generic english (region is dropped)")
+  func regionalEnglishCollapses() throws {
+    #expect(try TTSLanguage(languageCode: "en-GB") == .english)
+    #expect(try TTSLanguage(languageCode: "en_US") == .english)
+    #expect(try TTSLanguage(languageCode: "en-AU") == .english)
+  }
+
+  @Test("Full language names and model-name forms resolve")
+  func namesAndAliases() throws {
+    #expect(try TTSLanguage(languageCode: "english") == .english)
+    #expect(try TTSLanguage(languageCode: "beijing_dialect") == .beijingDialect)
+    #expect(try TTSLanguage(languageCode: "sichuan") == .sichuanDialect)
+  }
+
+  @Test("auto is an explicit, valid pass-through")
+  func autoPassThrough() throws {
+    #expect(try TTSLanguage(languageCode: "auto") == .auto)
+  }
+
+  @Test("modelName matches the on-device codec_language_id keys")
+  func modelNames() {
+    #expect(TTSLanguage.english.modelName == "english")
+    #expect(TTSLanguage.beijingDialect.modelName == "beijing_dialect")
+    #expect(TTSLanguage.sichuanDialect.modelName == "sichuan_dialect")
+    #expect(TTSLanguage.auto.modelName == "auto")
+  }
+
+  @Test("Locale init resolves the language component")
+  func localeInit() throws {
+    #expect(try TTSLanguage(locale: Locale(identifier: "en_GB")) == .english)
+    #expect(try TTSLanguage(locale: Locale(identifier: "de_DE")) == .german)
+  }
+
+  @Test("Unsupported languages throw unsupportedLanguage")
+  func unsupportedThrows() {
+    #expect(throws: VoxAltaError.self) {
+      _ = try TTSLanguage(languageCode: "xx")
+    }
+    // Dutch is a real language but not in the model's 12 supported languages.
+    #expect(throws: VoxAltaError.self) {
+      _ = try TTSLanguage(languageCode: "nl")
+    }
+  }
+
+  @Test("Every case has a non-empty modelName")
+  func allCasesHaveModelName() {
+    for lang in TTSLanguage.allCases {
+      #expect(!lang.modelName.isEmpty)
+    }
+  }
+}

--- a/docs/GENERATION_PIPELINE_PHASES.md
+++ b/docs/GENERATION_PIPELINE_PHASES.md
@@ -1,0 +1,93 @@
+# Generation Pipeline Phases — and Where the American Accent Leaks In
+
+Traces a generation prompt from the SwiftHablare entry point to WAV bytes, then
+pinpoints where an American-English accent is introduced. Verified against the
+checked-out source and an on-disk Qwen3-TTS model config on 2026-06-15.
+
+## The phases
+
+```
+caller (Produciesta / SwiftHablare)
+  │  text + voiceId + languageCode (e.g. "en")
+  ▼
+[1] VoxAltaVoiceProvider.generateAudio(...)            Sources/SwiftVoxAlta/VoxAltaVoiceProvider.swift:160
+  │   wraps text into GenerationContext(phrase:instruct:)
+  ▼
+[2] GenerationContext                                  Sources/SwiftVoxAlta/GenerationContext.swift:58
+  │   envelope: phrase + metadata (instruct). NO language/accent field here.
+  ▼
+[3] Route selection                                    VoxAltaVoiceProvider.swift:200
+  ├── Route 1: preset speaker (id matches presetSpeakers) → generateWithPresetSpeaker()
+  └── Route 2: cloned voice (cache lookup) → VoiceLockManager.generateAudio()
+  ▼
+[4] VoiceLockManager.generateAudio(context:...)        Sources/SwiftVoxAlta/VoiceLockManager.swift:147
+  │   extracts instruct, forwards text + language (default "en") + clone prompt
+  │   auto-chunks long text at sentence boundaries (splitAtSentences)
+  ▼
+[5] Qwen3TTSModel.generateWithClonePrompt(language:)   mlx-audio-swift .../Qwen3TTS/Qwen3TTS.swift:244
+  │   builds codec prefill, looks up language token, runs the AR loop
+  ▼
+[6] AudioConversion.mlxArrayToWAVData(...)             Sources/SwiftVoxAlta/AudioConversion.swift
+      → 24kHz / 16-bit / mono WAV Data
+```
+
+In every layer the language is just a **string passed straight through**. The
+defaults are `language: "en"` at VoiceLockManager.swift:69/150/203 and the
+caller's `languageCode`. Nothing translates, normalizes, or branches on it.
+
+## Where the American accent comes from
+
+There is **no "American English" setting anywhere**. The model has exactly one
+English. On-disk `codec_language_id` keys (verified from the downloaded
+`Qwen3-TTS-12Hz-1.7B-CustomVoice` config) are full names only:
+
+```
+chinese, english, german, italian, portuguese, spanish, japanese, korean,
+french, russian, beijing_dialect, sichuan_dialect
+```
+
+No `en-US`, no `en-GB`, no ISO codes. So the accent cannot be selected by the
+language code. It is introduced by three compounding mechanisms, in order of
+impact:
+
+### 1. `"en"` never resolves → NO language token is emitted at all  ⚠️ primary bug
+- VoxAlta passes the raw string `"en"` down to the model (it never calls the
+  resolver — confirmed: `resolveLanguage` is **dead code**, defined at
+  `Qwen3TTS.swift:861` and called from nowhere in the repo).
+- In the model, `languageId = langMap["en".lowercased()]` → `langMap` keys are
+  `english`/`chinese`/... so `langMap["en"]` is **nil**
+  (`Qwen3TTS.swift:308-309` for clone path, `:1490-1491` for base path).
+- With `languageId == nil`, the codec prefill takes the **"nothink" branch with
+  no language token** (`Qwen3TTS.swift:1504-1510`). The model gets *zero*
+  explicit language conditioning and free-runs on its training prior — which for
+  English is American-dominant. **This is the most likely leak.**
+- Passing `"english"` instead of `"en"` would at least inject the english
+  language token. Wiring `resolveLanguage("en") → "english"` into the VoxAlta
+  call sites is the cheapest correctness fix.
+
+### 2. Preset speakers are literally American (Route 1)
+`VoxAltaVoiceProvider.swift:46-60` — `aiden` is "Sunny American male voice";
+`ryan` is unlabeled but American-leaning. Picking these *is* picking an American
+accent. (The Chinese/Japanese/Korean presets carry their own accents.)
+
+### 3. Clone-anchor dilution on long text (Route 2)
+For cloned voices the accent lives entirely in the clone prompt's reference
+audio. If the `.vox` was cast from an American (or American-leaning Qwen)
+reference, output is American. Worse, long generations drift *away* from the
+clone anchor toward the model's American prior — this is the documented "TRIM
+ratio drift / ICL anchor dilution" that the sentence auto-chunking
+(VoiceLockManager.swift:262-313) was added to fight.
+
+## What this means for fixing it
+
+- A regional accent **cannot** be requested via `languageCode` — the model has no
+  representation for it. `"en-GB"` would resolve to `langMap["en-gb"] = nil`,
+  i.e. the same no-token free-run as `"en"`.
+- To get a non-American English accent you must control the **clone reference
+  audio** (cast the `.vox` from a reference in the target accent) and/or steer
+  via the `instruct` hint (e.g. "British RP accent") — though instruct steering
+  of accent is weak and unreliable in Qwen3-TTS.
+- First, fix mechanism #1: normalize the language code to the model's internal
+  name before it reaches `generateWithClonePrompt`/`generate`, so at least the
+  english language token is actually injected.
+```


### PR DESCRIPTION
# Release v0.14.0

## Summary
Introduces a type-safe `TTSLanguage` enum and threads a model-aligned language through the entire synthesis pipeline. Previously the pipeline passed a stringly-typed `"en"` literal that could silently fall through to un-conditioned generation; language is now expressed as an enum whose cases mirror the model's on-device `codec_language_id` keys and is forwarded as `language.modelName` to the speaker encoder.

### New Features
- **`TTSLanguage` enum** (`Sources/SwiftVoxAlta/TTSLanguage.swift`): cases mirror the model's `codec_language_id` keys exactly; resolves from BCP-47 tags, `Locale`, and loose aliases; exposes `modelName` and `logConsumption(stage:detail:)` tracing.
- **Language threading**: `VoiceLockManager.createLock` and both `generateAudio` overloads take `language: TTSLanguage` (was `String`), forwarding `language.modelName` so the tokenizer conditions on a key the model actually recognizes.

### Bug Fixes
- `DigaEngine` synthesis paths now pass `.english` / `TTSLanguage.english.modelName` explicitly instead of the bare `"en"` literal, fixing silent fall-through to un-conditioned generation.

### Breaking Changes
- `VoiceLockManager.generateAudio(...)` no longer defaults `language` — callers must pass an explicit `TTSLanguage`.
- `createLock`'s `language:` parameter changed type from `String` to `TTSLanguage` (defaults to `.english`).

### Testing
- New `TTSLanguageTests` suite; full unit-test suite passing on CI.

### Documentation
- `AGENTS.md` Recent Changes updated with the v0.14.0 entry; version bumped to 0.14.0 (reconciles the stale `DigaCLICore` `0.13.1-dev` marker).
- New `docs/GENERATION_PIPELINE_PHASES.md`.

### Release Hygiene
- `Package.swift` flipped to remote-only shape; `intrusive-memory/*` deps pinned to latest releases (SwiftHablare 6.1.1, SwiftAcervo 0.19.2, SwiftTuberia 0.7.4, vox-format 0.4.0).
- CI actions audited — all already on latest major.